### PR TITLE
Implement admin checklist management

### DIFF
--- a/src/Controller/Admin/ChecklistController.php
+++ b/src/Controller/Admin/ChecklistController.php
@@ -1,0 +1,76 @@
+<?php
+namespace App\Controller\Admin;
+
+use App\Entity\Checklist;
+use App\Form\ChecklistType;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class ChecklistController extends AbstractController
+{
+    public function __construct(private EntityManagerInterface $entityManager)
+    {
+    }
+
+    public function index(): Response
+    {
+        $checklists = $this->entityManager->getRepository(Checklist::class)->findAll();
+
+        return $this->render('admin/checklist/index.html.twig', [
+            'checklists' => $checklists,
+        ]);
+    }
+
+    public function new(Request $request): Response
+    {
+        $checklist = new Checklist();
+        $form = $this->createForm(ChecklistType::class, $checklist);
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted() && $form->isValid()) {
+            $this->entityManager->persist($checklist);
+            $this->entityManager->flush();
+
+            return $this->redirectToRoute('admin_checklists');
+        }
+
+        return $this->render('admin/checklist/new.html.twig', [
+            'form' => $form->createView(),
+        ]);
+    }
+
+    public function edit(Request $request, int $id): Response
+    {
+        $checklist = $this->entityManager->getRepository(Checklist::class)->find($id);
+        if (!$checklist) {
+            throw $this->createNotFoundException();
+        }
+
+        $form = $this->createForm(ChecklistType::class, $checklist);
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted() && $form->isValid()) {
+            $this->entityManager->flush();
+
+            return $this->redirectToRoute('admin_checklists');
+        }
+
+        return $this->render('admin/checklist/edit.html.twig', [
+            'form' => $form->createView(),
+            'checklist' => $checklist,
+        ]);
+    }
+
+    public function delete(Request $request, int $id): Response
+    {
+        $checklist = $this->entityManager->getRepository(Checklist::class)->find($id);
+        if ($checklist) {
+            $this->entityManager->remove($checklist);
+            $this->entityManager->flush();
+        }
+
+        return $this->redirectToRoute('admin_checklists');
+    }
+}

--- a/src/Form/ChecklistType.php
+++ b/src/Form/ChecklistType.php
@@ -1,0 +1,36 @@
+<?php
+namespace App\Form;
+
+use App\Entity\Checklist;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\TextareaType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class ChecklistType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder
+            ->add('title', TextType::class, [
+                'label' => 'Titel',
+            ])
+            ->add('targetEmail', TextType::class, [
+                'label' => 'Ziel-E-Mail',
+            ])
+            ->add('emailTemplate', TextareaType::class, [
+                'required' => false,
+                'label' => 'E-Mail-Template',
+                'attr' => ['rows' => 10],
+            ])
+        ;
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'data_class' => Checklist::class,
+        ]);
+    }
+}

--- a/templates/admin/checklist/edit.html.twig
+++ b/templates/admin/checklist/edit.html.twig
@@ -1,0 +1,15 @@
+{% extends 'base.html.twig' %}
+
+{% block title %}Stückliste bearbeiten - Besteller{% endblock %}
+
+{% block body %}
+<h1>Stückliste bearbeiten</h1>
+
+{{ form_start(form) }}
+    {{ form_row(form.title) }}
+    {{ form_row(form.targetEmail) }}
+    {{ form_row(form.emailTemplate) }}
+    <button class="btn btn-primary">Speichern</button>
+    <a href="{{ path('admin_checklists') }}" class="btn btn-secondary">Zurück</a>
+{{ form_end(form) }}
+{% endblock %}

--- a/templates/admin/checklist/index.html.twig
+++ b/templates/admin/checklist/index.html.twig
@@ -1,0 +1,39 @@
+{% extends 'base.html.twig' %}
+
+{% block title %}Stücklisten - Besteller{% endblock %}
+
+{% block body %}
+<div class="d-flex justify-content-between align-items-center mb-4">
+    <h1>Stücklisten</h1>
+    <a href="{{ path('admin_checklist_new') }}" class="btn btn-primary">Neue Stückliste</a>
+</div>
+
+{% if checklists is empty %}
+    <p>Keine Stücklisten vorhanden.</p>
+{% else %}
+<table class="table">
+    <thead>
+        <tr>
+            <th>Titel</th>
+            <th>Ziel-E-Mail</th>
+            <th></th>
+        </tr>
+    </thead>
+    <tbody>
+    {% for checklist in checklists %}
+        <tr>
+            <td>{{ checklist.title }}</td>
+            <td>{{ checklist.targetEmail }}</td>
+            <td class="text-end">
+                <a href="{{ path('admin_checklist_edit', {id: checklist.id}) }}" class="btn btn-sm btn-outline-primary">Bearbeiten</a>
+                <form method="post" action="{{ path('admin_checklist_delete', {id: checklist.id}) }}" style="display:inline-block" onsubmit="return confirm('Löschen?');">
+                    <input type="hidden" name="_token" value="{{ csrf_token('delete' ~ checklist.id) }}">
+                    <button class="btn btn-sm btn-outline-danger">Löschen</button>
+                </form>
+            </td>
+        </tr>
+    {% endfor %}
+    </tbody>
+</table>
+{% endif %}
+{% endblock %}

--- a/templates/admin/checklist/new.html.twig
+++ b/templates/admin/checklist/new.html.twig
@@ -1,0 +1,15 @@
+{% extends 'base.html.twig' %}
+
+{% block title %}Neue Stückliste - Besteller{% endblock %}
+
+{% block body %}
+<h1>Neue Stückliste</h1>
+
+{{ form_start(form) }}
+    {{ form_row(form.title) }}
+    {{ form_row(form.targetEmail) }}
+    {{ form_row(form.emailTemplate) }}
+    <button class="btn btn-primary">Speichern</button>
+    <a href="{{ path('admin_checklists') }}" class="btn btn-secondary">Abbrechen</a>
+{{ form_end(form) }}
+{% endblock %}


### PR DESCRIPTION
## Summary
- add controller for admin checklists
- add form type for checklist entity
- add templates to list, create and edit checklists

## Testing
- `php -l src/Form/ChecklistType.php`
- `php -l src/Controller/Admin/ChecklistController.php`
- `php bin/console debug:router admin_checklist_new | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_6883ed54caec8331805ef2457c18cd2a