### PR TITLE
Add admin submissions listing

### DIFF
--- a/config/routes.yaml
+++ b/config/routes.yaml
@@ -64,6 +64,13 @@ admin_submissions_checklist:
     controller: App\Controller\Admin\SubmissionController::byChecklist
     requirements:
         checklistId: '\d+'
+admin_submission_delete:
+    path: /admin/submissions/{id}/delete
+    controller: App\Controller\Admin\SubmissionController::delete
+    methods: [POST]
+    requirements:
+        id: '\d+'
+
 
 # Gruppen-Verwaltung
 admin_group_create:

--- a/src/Controller/Admin/SubmissionController.php
+++ b/src/Controller/Admin/SubmissionController.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace App\Controller\Admin;
+
+use App\Entity\Submission;
+use App\Repository\ChecklistRepository;
+use App\Repository\SubmissionRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[IsGranted('ROLE_ADMIN')]
+class SubmissionController extends AbstractController
+{
+    public function __construct(
+        private EntityManagerInterface $entityManager,
+        private ChecklistRepository $checklistRepository,
+        private SubmissionRepository $submissionRepository
+    ) {
+    }
+
+    public function index(): Response
+    {
+        $checklists = $this->checklistRepository->findAll();
+
+        return $this->render('admin/submission/index.html.twig', [
+            'checklists' => $checklists,
+        ]);
+    }
+
+    public function byChecklist(int $checklistId): Response
+    {
+        $checklist = $this->checklistRepository->find($checklistId);
+        if (!$checklist) {
+            throw $this->createNotFoundException('Stückliste nicht gefunden');
+        }
+
+        $submissions = $this->submissionRepository->findByChecklist($checklist);
+
+        return $this->render('admin/submission/by_checklist.html.twig', [
+            'checklist' => $checklist,
+            'submissions' => $submissions,
+        ]);
+    }
+
+    public function delete(Request $request, Submission $submission): Response
+    {
+        $checklistId = $submission->getChecklist()->getId();
+
+        if ($this->isCsrfTokenValid('delete' . $submission->getId(), $request->request->get('_token'))) {
+            $this->entityManager->remove($submission);
+            $this->entityManager->flush();
+            $this->addFlash('success', 'Einsendung wurde erfolgreich gel\xC3\xB6scht.');
+        }
+
+        return $this->redirectToRoute('admin_submissions_checklist', ['checklistId' => $checklistId]);
+    }
+}

--- a/src/Repository/SubmissionRepository.php
+++ b/src/Repository/SubmissionRepository.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\Checklist;
+use App\Entity\Submission;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<Submission>
+ */
+class SubmissionRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, Submission::class);
+    }
+
+    /**
+     * @return Submission[]
+     */
+    public function findByChecklist(Checklist $checklist): array
+    {
+        return $this->createQueryBuilder('s')
+            ->andWhere('s.checklist = :checklist')
+            ->setParameter('checklist', $checklist)
+            ->orderBy('s.submittedAt', 'DESC')
+            ->getQuery()
+            ->getResult();
+    }
+}

--- a/templates/admin/base.html.twig
+++ b/templates/admin/base.html.twig
@@ -46,8 +46,8 @@
                             </a>
                         </li>
                         <li class="nav-item">
-                            <a class="nav-link" href="#">
-                                <i class="fas fa-paper-plane"></i> Einreichungen
+                            <a class="nav-link {% if app.request.get('_route') starts with 'admin_submissions' %}active{% endif %}" href="{{ path('admin_submissions') }}">
+                                <i class='fas fa-paper-plane'></i> Einreichungen
                             </a>
                         </li>
                         <li class="nav-item">

--- a/templates/admin/submission/by_checklist.html.twig
+++ b/templates/admin/submission/by_checklist.html.twig
@@ -1,0 +1,81 @@
+{% extends 'admin/base.html.twig' %}
+
+{% block title %}Einsendungen – {{ checklist.title }}{% endblock %}
+
+{% block content %}
+<div class="d-flex justify-content-between align-items-center mb-4">
+    <h1>Einsendungen – {{ checklist.title }}</h1>
+    <a href="{{ path('admin_submissions') }}" class="btn btn-secondary">
+        <i class="fas fa-arrow-left"></i> Zurück
+    </a>
+</div>
+
+{% for message in app.flashes('success') %}
+    <div class="alert alert-success alert-dismissible fade show" role="alert">
+        {{ message }}
+        <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
+    </div>
+{% endfor %}
+
+{% if submissions is empty %}
+    <div class="alert alert-info">Noch keine Einsendungen vorhanden.</div>
+{% else %}
+    <div class="card">
+        <div class="card-body p-0">
+            <div class="table-responsive">
+                <table class="table table-hover mb-0">
+                    <thead class="table-light">
+                    <tr>
+                        <th>Datum</th>
+                        <th>Name</th>
+                        <th>Mitarbeiter-ID</th>
+                        <th>E-Mail-Inhalt</th>
+                        <th>Aktionen</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    {% for submission in submissions %}
+                        <tr>
+                            <td>{{ submission.submittedAt|date('d.m.Y H:i') }}</td>
+                            <td>{{ submission.name }}</td>
+                            <td>{{ submission.mitarbeiterId }}</td>
+                            <td><pre class="mb-0">{{ submission.generatedEmail|striptags }}</pre></td>
+                            <td>
+                                <button type="button" class="btn btn-sm btn-outline-danger"
+                                        data-bs-toggle="modal"
+                                        data-bs-target="#deleteModal{{ submission.id }}">
+                                    <i class="fas fa-trash"></i>
+                                </button>
+                            </td>
+                        </tr>
+                    {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+
+    {% for submission in submissions %}
+        <div class="modal fade" id="deleteModal{{ submission.id }}" tabindex="-1">
+            <div class="modal-dialog">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <h5 class="modal-title">Einsendung löschen</h5>
+                        <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+                    </div>
+                    <div class="modal-body">
+                        <p>Möchten Sie die Einsendung von <strong>{{ submission.name }}</strong> wirklich löschen?</p>
+                    </div>
+                    <div class="modal-footer">
+                        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Abbrechen</button>
+                        <form method="post" action="{{ path('admin_submission_delete', {id: submission.id}) }}" class="d-inline">
+                            <input type="hidden" name="_token" value="{{ csrf_token('delete' ~ submission.id) }}">
+                            <button type="submit" class="btn btn-danger">Löschen</button>
+                        </form>
+                    </div>
+                </div>
+            </div>
+        </div>
+    {% endfor %}
+{% endif %}
+{% endblock %}

--- a/templates/admin/submission/index.html.twig
+++ b/templates/admin/submission/index.html.twig
@@ -1,0 +1,44 @@
+{% extends 'admin/base.html.twig' %}
+
+{% block title %}Einsendungen{% endblock %}
+
+{% block content %}
+<div class="d-flex justify-content-between align-items-center mb-4">
+    <h1>Einsendungen</h1>
+</div>
+
+{% if checklists is empty %}
+    <div class="alert alert-info">Noch keine Stücklisten vorhanden.</div>
+{% else %}
+    <div class="card">
+        <div class="card-body p-0">
+            <div class="table-responsive">
+                <table class="table table-hover mb-0">
+                    <thead class="table-light">
+                    <tr>
+                        <th>Titel</th>
+                        <th class="text-center">Einreichungen</th>
+                        <th>Aktionen</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    {% for checklist in checklists %}
+                        <tr>
+                            <td>{{ checklist.title }}</td>
+                            <td class="text-center">
+                                <span class="badge bg-info">{{ checklist.submissions|length }}</span>
+                            </td>
+                            <td>
+                                <a href="{{ path('admin_submissions_checklist', {checklistId: checklist.id}) }}" class="btn btn-sm btn-outline-primary">
+                                    Anzeigen
+                                </a>
+                            </td>
+                        </tr>
+                    {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+{% endif %}
+{% endblock %}


### PR DESCRIPTION
## Summary
- create `SubmissionRepository` for listing submissions per checklist
- implement `SubmissionController` to view and delete submissions
- add templates for submission index and checklist view
- link submission section in admin sidebar and routing

## Testing
- `php -l src/Repository/SubmissionRepository.php`
- `php -l src/Controller/Admin/SubmissionController.php`
- `php -l config/routes.yaml`


------
https://chatgpt.com/codex/tasks/task_e_68847ca178e08331a97ef4aff86f1874