### PR TITLE
Fix text field to be multiline textarea

### DIFF
--- a/templates/checklist/form.html.twig
+++ b/templates/checklist/form.html.twig
@@ -40,10 +40,10 @@
                                         <label class="form-label">{{ item.label }}</label>
                                         
                                         {% if item.type == 'text' %}
-                                            <input type="text" 
-                                                   class="form-control" 
-                                                   name="item_{{ item.id }}" 
-                                                   placeholder="Bitte eingeben...">
+                                            <textarea class="form-control"
+                                                      name="item_{{ item.id }}"
+                                                      rows="4"
+                                                      placeholder="Bitte eingeben..."></textarea>
                                         
                                         {% elseif item.type == 'radio' %}
                                             {% for option in item.optionsArray %}


### PR DESCRIPTION
## Summary
- use `<textarea>` instead of `<input>` for text items so users can enter multi-line text

## Testing
- `composer validate --no-interaction`


------
https://chatgpt.com/codex/tasks/task_e_688481a7b828833181d9785932d839b0