### PR TITLE
Implement user management for admins

### DIFF
--- a/config/routes.yaml
+++ b/config/routes.yaml
@@ -135,3 +135,25 @@ admin_checklist_email_template_reset:
 admin_email_settings:
     path: /admin/email-settings
     controller: App\Controller\Admin\EmailSettingsController::edit
+
+# Benutzerverwaltung
+admin_users:
+    path: /admin/users
+    controller: App\Controller\Admin\UserController::index
+
+admin_user_new:
+    path: /admin/users/new
+    controller: App\Controller\Admin\UserController::new
+
+admin_user_edit:
+    path: /admin/users/{id}/edit
+    controller: App\Controller\Admin\UserController::edit
+    requirements:
+        id: '\d+'
+
+admin_user_delete:
+    path: /admin/users/{id}/delete
+    controller: App\Controller\Admin\UserController::delete
+    methods: [POST]
+    requirements:
+        id: '\d+'

--- a/src/Controller/Admin/UserController.php
+++ b/src/Controller/Admin/UserController.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace App\Controller\Admin;
+
+use App\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[IsGranted('ROLE_ADMIN')]
+class UserController extends AbstractController
+{
+    public function __construct(
+        private EntityManagerInterface $entityManager,
+        private UserPasswordHasherInterface $passwordHasher
+    ) {
+    }
+
+    public function index(): Response
+    {
+        $users = $this->entityManager->getRepository(User::class)->findAll();
+
+        return $this->render('admin/user/index.html.twig', [
+            'users' => $users,
+        ]);
+    }
+
+    public function new(Request $request): Response
+    {
+        if ($request->isMethod('POST')) {
+            $email = trim((string) $request->request->get('email'));
+            $password = (string) $request->request->get('password');
+
+            if (strlen($password) < 16) {
+                $this->addFlash('error', 'Das Passwort muss mindestens 16 Zeichen lang sein.');
+            } elseif ($this->entityManager->getRepository(User::class)->findOneBy(['email' => $email])) {
+                $this->addFlash('error', 'Ein Benutzer mit dieser E-Mail existiert bereits.');
+            } else {
+                $user = new User();
+                $user->setEmail($email);
+                $user->setRoles(['ROLE_ADMIN']);
+                $user->setPassword($this->passwordHasher->hashPassword($user, $password));
+
+                $this->entityManager->persist($user);
+                $this->entityManager->flush();
+
+                $this->addFlash('success', 'Benutzer wurde erfolgreich erstellt.');
+
+                return $this->redirectToRoute('admin_users');
+            }
+        }
+
+        return $this->render('admin/user/new.html.twig');
+    }
+
+    public function edit(Request $request, User $user): Response
+    {
+        if ($request->isMethod('POST')) {
+            $email = trim((string) $request->request->get('email'));
+            $password = (string) $request->request->get('password');
+
+            if ($password !== '' && strlen($password) < 16) {
+                $this->addFlash('error', 'Das Passwort muss mindestens 16 Zeichen lang sein.');
+            } else {
+                $existing = $this->entityManager->getRepository(User::class)->findOneBy(['email' => $email]);
+                if ($existing && $existing->getId() !== $user->getId()) {
+                    $this->addFlash('error', 'Ein Benutzer mit dieser E-Mail existiert bereits.');
+                } else {
+                    $user->setEmail($email);
+
+                    if ($password !== '') {
+                        $user->setPassword(
+                            $this->passwordHasher->hashPassword($user, $password)
+                        );
+                    }
+
+                    $this->entityManager->flush();
+
+                    $this->addFlash('success', 'Benutzer wurde erfolgreich aktualisiert.');
+
+                    return $this->redirectToRoute('admin_users');
+                }
+            }
+        }
+
+        return $this->render('admin/user/edit.html.twig', [
+            'user' => $user,
+        ]);
+    }
+
+    public function delete(Request $request, User $user): Response
+    {
+        if ($this->isCsrfTokenValid('delete' . $user->getId(), (string) $request->request->get('_token'))) {
+            $this->entityManager->remove($user);
+            $this->entityManager->flush();
+            $this->addFlash('success', 'Benutzer wurde erfolgreich gelöscht.');
+        }
+
+        return $this->redirectToRoute('admin_users');
+    }
+}

--- a/templates/admin/base.html.twig
+++ b/templates/admin/base.html.twig
@@ -56,7 +56,7 @@
                             </a>
                         </li>
                         <li class="nav-item">
-                            <a class="nav-link" href="#">
+                            <a class="nav-link {% if app.request.get('_route') starts with 'admin_user' %}active{% endif %}" href="{{ path('admin_users') }}">
                                 <i class="fas fa-users"></i> Benutzer
                             </a>
                         </li>

--- a/templates/admin/user/edit.html.twig
+++ b/templates/admin/user/edit.html.twig
@@ -1,0 +1,38 @@
+{% extends 'admin/base.html.twig' %}
+
+{% block title %}Benutzer bearbeiten{% endblock %}
+
+{% block content %}
+<div class="d-flex justify-content-between align-items-center mb-4">
+    <h1>Benutzer bearbeiten</h1>
+    <a href="{{ path('admin_users') }}" class="btn btn-secondary">
+        <i class="fas fa-arrow-left"></i> Zurück zur Übersicht
+    </a>
+</div>
+
+<div class="row justify-content-center">
+    <div class="col-md-6">
+        <div class="card">
+            <div class="card-body">
+                <form method="post">
+                    <div class="mb-3">
+                        <label for="email" class="form-label">E-Mail <span class="text-danger">*</span></label>
+                        <input type="email" id="email" name="email" class="form-control" value="{{ user.email }}" required>
+                    </div>
+                    <div class="mb-3">
+                        <label for="password" class="form-label">Neues Passwort (optional)</label>
+                        <input type="password" id="password" name="password" class="form-control" placeholder="Mindestens 16 Zeichen">
+                        <div class="form-text">Leer lassen, um das Passwort nicht zu ändern.</div>
+                    </div>
+                    <div class="d-flex gap-2">
+                        <button type="submit" class="btn btn-primary">
+                            <i class="fas fa-save"></i> Änderungen speichern
+                        </button>
+                        <a href="{{ path('admin_users') }}" class="btn btn-outline-secondary">Abbrechen</a>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/templates/admin/user/index.html.twig
+++ b/templates/admin/user/index.html.twig
@@ -1,0 +1,92 @@
+{% extends 'admin/base.html.twig' %}
+
+{% block title %}Benutzer verwalten{% endblock %}
+
+{% block content %}
+<div class="d-flex justify-content-between align-items-center mb-4">
+    <h1>Benutzer verwalten</h1>
+    <a href="{{ path('admin_user_new') }}" class="btn btn-primary">
+        <i class="fas fa-plus"></i> Neuen Benutzer anlegen
+    </a>
+</div>
+
+{% for message in app.flashes('success') %}
+    <div class="alert alert-success alert-dismissible fade show" role="alert">
+        {{ message }}
+        <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
+    </div>
+{% endfor %}
+{% for message in app.flashes('error') %}
+    <div class="alert alert-danger alert-dismissible fade show" role="alert">
+        {{ message }}
+        <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
+    </div>
+{% endfor %}
+
+{% if users is empty %}
+    <div class="alert alert-info">Noch keine Benutzer vorhanden.</div>
+{% else %}
+    <div class="card">
+        <div class="card-body p-0">
+            <div class="table-responsive">
+                <table class="table table-hover mb-0">
+                    <thead class="table-light">
+                    <tr>
+                        <th>ID</th>
+                        <th>E-Mail</th>
+                        <th>Aktionen</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    {% for user in users %}
+                        <tr>
+                            <td>{{ user.id }}</td>
+                            <td>{{ user.email }}</td>
+                            <td>
+                                <div class="btn-group btn-group-sm">
+                                    <a href="{{ path('admin_user_edit', {'id': user.id}) }}" class="btn btn-outline-primary" title="Bearbeiten">
+                                        <i class="fas fa-edit"></i>
+                                    </a>
+                                    {% if user.id != app.user.id %}
+                                        <button type="button" class="btn btn-outline-danger" data-bs-toggle="modal" data-bs-target="#deleteModal{{ user.id }}" title="Löschen">
+                                            <i class="fas fa-trash"></i>
+                                        </button>
+                                    {% endif %}
+                                </div>
+                            </td>
+                        </tr>
+                    {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+
+    {% for user in users %}
+        {% if user.id != app.user.id %}
+        <div class="modal fade" id="deleteModal{{ user.id }}" tabindex="-1">
+            <div class="modal-dialog">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <h5 class="modal-title">Benutzer löschen</h5>
+                        <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+                    </div>
+                    <div class="modal-body">
+                        Möchten Sie den Benutzer <strong>{{ user.email }}</strong> wirklich löschen?
+                    </div>
+                    <div class="modal-footer">
+                        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Abbrechen</button>
+                        <form method="post" action="{{ path('admin_user_delete', {'id': user.id}) }}" class="d-inline">
+                            <input type="hidden" name="_token" value="{{ csrf_token('delete' ~ user.id) }}">
+                            <button type="submit" class="btn btn-danger">
+                                <i class="fas fa-trash"></i> Löschen
+                            </button>
+                        </form>
+                    </div>
+                </div>
+            </div>
+        </div>
+        {% endif %}
+    {% endfor %}
+{% endif %}
+{% endblock %}

--- a/templates/admin/user/new.html.twig
+++ b/templates/admin/user/new.html.twig
@@ -1,0 +1,37 @@
+{% extends 'admin/base.html.twig' %}
+
+{% block title %}Neuen Benutzer anlegen{% endblock %}
+
+{% block content %}
+<div class="d-flex justify-content-between align-items-center mb-4">
+    <h1>Neuen Benutzer anlegen</h1>
+    <a href="{{ path('admin_users') }}" class="btn btn-secondary">
+        <i class="fas fa-arrow-left"></i> Zurück zur Übersicht
+    </a>
+</div>
+
+<div class="row justify-content-center">
+    <div class="col-md-6">
+        <div class="card">
+            <div class="card-body">
+                <form method="post">
+                    <div class="mb-3">
+                        <label for="email" class="form-label">E-Mail <span class="text-danger">*</span></label>
+                        <input type="email" id="email" name="email" class="form-control" required>
+                    </div>
+                    <div class="mb-3">
+                        <label for="password" class="form-label">Passwort <span class="text-danger">*</span></label>
+                        <input type="password" id="password" name="password" class="form-control" required placeholder="Mindestens 16 Zeichen">
+                    </div>
+                    <div class="d-flex gap-2">
+                        <button type="submit" class="btn btn-primary">
+                            <i class="fas fa-save"></i> Benutzer erstellen
+                        </button>
+                        <a href="{{ path('admin_users') }}" class="btn btn-outline-secondary">Abbrechen</a>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add UserController for admin management
- link user management in admin navigation
- create user management templates
- define routes for user CRUD

## Testing
- `composer install`
- `php bin/console debug:router | grep admin_user`

------
https://chatgpt.com/codex/tasks/task_e_6884842b1b448331ac6307b3a8d79bd1