### PR TITLE
Render HTML email content in admin submissions list

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Ziel dieser Anwendung ist die digitale Erfassung von benötigter Ausstattung fü
 **damit** ich den Überblick über übermittelte Daten habe.
 
 **Akzeptanzkriterien:**
- - Liste pro Stückliste mit Datum, Name, Mitarbeiter-ID und gerendertem E-Mail-Inhalt in einem iFrame mit fester Breite
+ - Liste pro Stückliste mit Datum, Name, Mitarbeiter-ID und E-Mail-Inhalt über einen Link in neuem Fenster
 - Einsendung löschen können um sie erneut absendbar zu machen
 - Keine Downloadfunktion erforderlich
 

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Ziel dieser Anwendung ist die digitale Erfassung von benötigter Ausstattung fü
 **damit** ich den Überblick über übermittelte Daten habe.
 
 **Akzeptanzkriterien:**
-- Liste pro Stückliste mit Datum, Name, Mitarbeiter-ID und E-Mail-Inhalt (als Klartext)
+- Liste pro Stückliste mit Datum, Name, Mitarbeiter-ID und gerendertem E-Mail-Inhalt
 - Einsendung löschen können um sie erneut absendbar zu machen
 - Keine Downloadfunktion erforderlich
 

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Ziel dieser Anwendung ist die digitale Erfassung von benötigter Ausstattung fü
 **damit** ich den Überblick über übermittelte Daten habe.
 
 **Akzeptanzkriterien:**
-- Liste pro Stückliste mit Datum, Name, Mitarbeiter-ID und gerendertem E-Mail-Inhalt
+ - Liste pro Stückliste mit Datum, Name, Mitarbeiter-ID und gerendertem E-Mail-Inhalt in einem iFrame mit fester Breite
 - Einsendung löschen können um sie erneut absendbar zu machen
 - Keine Downloadfunktion erforderlich
 

--- a/config/routes.yaml
+++ b/config/routes.yaml
@@ -64,6 +64,11 @@ admin_submissions_checklist:
     controller: App\Controller\Admin\SubmissionController::byChecklist
     requirements:
         checklistId: '\d+'
+admin_submission_html:
+    path: /admin/submissions/{id}/html
+    controller: App\Controller\Admin\SubmissionController::viewHtml
+    requirements:
+        id: '\d+'
 admin_submission_delete:
     path: /admin/submissions/{id}/delete
     controller: App\Controller\Admin\SubmissionController::delete

--- a/src/Controller/Admin/SubmissionController.php
+++ b/src/Controller/Admin/SubmissionController.php
@@ -45,6 +45,13 @@ class SubmissionController extends AbstractController
         ]);
     }
 
+    public function viewHtml(Submission $submission): Response
+    {
+        return new Response($submission->getGeneratedEmail(), 200, [
+            'Content-Type' => 'text/html'
+        ]);
+    }
+
     public function delete(Request $request, Submission $submission): Response
     {
         $checklistId = $submission->getChecklist()->getId();

--- a/templates/admin/submission/by_checklist.html.twig
+++ b/templates/admin/submission/by_checklist.html.twig
@@ -39,7 +39,7 @@
                             <td>{{ submission.submittedAt|date('d.m.Y H:i') }}</td>
                             <td>{{ submission.name }}</td>
                             <td>{{ submission.mitarbeiterId }}</td>
-                            <td><pre class="mb-0">{{ submission.generatedEmail|striptags }}</pre></td>
+                            <td>{{ submission.generatedEmail|raw }}</td>
                             <td>
                                 <button type="button" class="btn btn-sm btn-outline-danger"
                                         data-bs-toggle="modal"

--- a/templates/admin/submission/by_checklist.html.twig
+++ b/templates/admin/submission/by_checklist.html.twig
@@ -39,7 +39,10 @@
                             <td>{{ submission.submittedAt|date('d.m.Y H:i') }}</td>
                             <td>{{ submission.name }}</td>
                             <td>{{ submission.mitarbeiterId }}</td>
-                            <td>{{ submission.generatedEmail|raw }}</td>
+                            <td>
+                                <iframe srcdoc="{{ submission.generatedEmail|e('html_attr') }}"
+                                        style="width: 600px; height: 400px; border: 1px solid #dee2e6;"></iframe>
+                            </td>
                             <td>
                                 <button type="button" class="btn btn-sm btn-outline-danger"
                                         data-bs-toggle="modal"

--- a/templates/admin/submission/by_checklist.html.twig
+++ b/templates/admin/submission/by_checklist.html.twig
@@ -40,8 +40,7 @@
                             <td>{{ submission.name }}</td>
                             <td>{{ submission.mitarbeiterId }}</td>
                             <td>
-                                <iframe srcdoc="{{ submission.generatedEmail|e('html_attr') }}"
-                                        style="width: 600px; height: 400px; border: 1px solid #dee2e6;"></iframe>
+                                <a href="{{ path('admin_submission_html', {id: submission.id}) }}" target="_blank">Anzeigen</a>
                             </td>
                             <td>
                                 <button type="button" class="btn btn-sm btn-outline-danger"


### PR DESCRIPTION
## Summary
- render the `generatedEmail` field without stripping tags so the email is displayed as HTML
- update README to mention that email content is rendered

## Testing
- `composer run test` *(fails: Script "test" is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68848741d904833195a24d19cdb6613a