### PR TITLE
Redirect to admin after login

### DIFF
--- a/config/packages/prod/security.yaml
+++ b/config/packages/prod/security.yaml
@@ -8,6 +8,8 @@ security:
                 enable_csrf: true
                 # Force HTTPS for login in production
                 require_previous_session: false
+                default_target_path: /admin
+                always_use_default_target_path: true
             logout:
                 path: app_logout
                 target: app_login

--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -23,6 +23,8 @@ security:
                 login_path: app_login
                 check_path: app_login
                 enable_csrf: true
+                default_target_path: /admin
+                always_use_default_target_path: true
             logout:
                 path: app_logout
                 target: app_login

--- a/src/Controller/SecurityController.php
+++ b/src/Controller/SecurityController.php
@@ -11,6 +11,9 @@ class SecurityController extends AbstractController
 {
     public function login(AuthenticationUtils $authenticationUtils, Request $request): Response
     {
+        if ($this->getUser()) {
+            return $this->redirectToRoute('admin_dashboard');
+        }
         // get the login error if there is one
         $error = $authenticationUtils->getLastAuthenticationError();
 


### PR DESCRIPTION
## Summary
- redirect already-logged in users from login page to admin dashboard
- send logged-in users to `/admin` after successful login

## Testing
- `php -l src/Controller/SecurityController.php`
- `composer validate --no-check-all --strict`
- `make test` *(fails: docker not installed)*

------
https://chatgpt.com/codex/tasks/task_e_688493d539a88331906f17abb63f416c