### PR TITLE
Expand groups on checklist edit

### DIFF
--- a/templates/admin/checklist/edit.html.twig
+++ b/templates/admin/checklist/edit.html.twig
@@ -80,10 +80,10 @@
                         {% for group in checklist.groups %}
                             <div class="accordion-item">
                                 <h2 class="accordion-header" id="heading{{ group.id }}">
-                                    <button class="accordion-button collapsed" type="button" 
-                                            data-bs-toggle="collapse" 
-                                            data-bs-target="#collapse{{ group.id }}" 
-                                            aria-expanded="false">
+                                    <button class="accordion-button" type="button"
+                                            data-bs-toggle="collapse"
+                                            data-bs-target="#collapse{{ group.id }}"
+                                            aria-expanded="true">
                                         <div class="d-flex justify-content-between align-items-center w-100 me-2">
                                             <div>
                                                 <strong>{{ group.title }}</strong>
@@ -95,7 +95,7 @@
                                         </div>
                                     </button>
                                 </h2>
-                                <div id="collapse{{ group.id }}" class="accordion-collapse collapse" 
+                                <div id="collapse{{ group.id }}" class="accordion-collapse collapse show"
                                      data-bs-parent="#groupsAccordion">
                                     <div class="accordion-body">
                                         <div class="d-flex justify-content-between align-items-center mb-3">


### PR DESCRIPTION
## Summary
- update group accordion behavior so groups are expanded by default on the checklist edit page

## Testing
- `composer validate --no-check-all --strict`

------
https://chatgpt.com/codex/tasks/task_e_688494da40c483319b9c3807b9720fde