### PR TITLE
Implement '(aktiv)' default options

### DIFF
--- a/src/Controller/Admin/GroupController.php
+++ b/src/Controller/Admin/GroupController.php
@@ -88,8 +88,17 @@ class GroupController extends AbstractController
 
             // Handle options für Checkbox/Radio
             if (in_array($item->getType(), [GroupItem::TYPE_CHECKBOX, GroupItem::TYPE_RADIO])) {
-                $options = array_filter(array_map('trim', explode("\n", $request->request->get('options', ''))));
-                $item->setOptions(json_encode($options));
+                $lines = array_filter(array_map('trim', explode("\n", $request->request->get('options', ''))));
+                $options = [];
+                foreach ($lines as $line) {
+                    $active = false;
+                    if (preg_match('/\(aktiv\)$/i', $line)) {
+                        $active = true;
+                        $line = trim(preg_replace('/\(aktiv\)$/i', '', $line));
+                    }
+                    $options[] = ['label' => $line, 'active' => $active];
+                }
+                $item->setOptionsWithActive($options);
             }
 
             $this->entityManager->persist($item);
@@ -115,8 +124,17 @@ class GroupController extends AbstractController
 
             // Handle options für Checkbox/Radio
             if (in_array($item->getType(), [GroupItem::TYPE_CHECKBOX, GroupItem::TYPE_RADIO])) {
-                $options = array_filter(array_map('trim', explode("\n", $request->request->get('options', ''))));
-                $item->setOptions(json_encode($options));
+                $lines = array_filter(array_map('trim', explode("\n", $request->request->get('options', ''))));
+                $options = [];
+                foreach ($lines as $line) {
+                    $active = false;
+                    if (preg_match('/\(aktiv\)$/i', $line)) {
+                        $active = true;
+                        $line = trim(preg_replace('/\(aktiv\)$/i', '', $line));
+                    }
+                    $options[] = ['label' => $line, 'active' => $active];
+                }
+                $item->setOptionsWithActive($options);
             }
 
             $this->entityManager->flush();

--- a/src/Entity/GroupItem.php
+++ b/src/Entity/GroupItem.php
@@ -112,7 +112,7 @@ class GroupItem
         }
 
         // Altes Format: einfache Liste von Strings
-        if (!empty($decoded) && is_string($decoded[0])) {
+        if (!empty($decoded) && array_key_exists(0, $decoded) && is_string($decoded[0])) {
             return array_map(
                 fn(string $label) => ['label' => $label, 'active' => false],
                 $decoded

--- a/src/Entity/GroupItem.php
+++ b/src/Entity/GroupItem.php
@@ -85,10 +85,10 @@ class GroupItem
     /**
      * Speichert eine Liste von Optionen (nur Labels, alle inaktiv)
      */
-    public function setOptionsArray(array $options): static
+    public function setOptionsArray(array $options, bool $active = false): static
     {
         $structured = array_map(
-            fn(string $label) => ['label' => $label, 'active' => false],
+            fn(string $label) => ['label' => $label, 'active' => $active],
             $options
         );
         $this->options = json_encode($structured);

--- a/templates/admin/group/add_item.html.twig
+++ b/templates/admin/group/add_item.html.twig
@@ -47,7 +47,7 @@
                                   id="options" 
                                   name="options" 
                                   rows="5"
-                                  placeholder="Eine Option pro Zeile&#10;z.B.:&#10;MacBook Pro 14\"&#10;MacBook Pro 16\"&#10;ThinkPad X1 (aktiv)">{% if item.options %}{{ item.optionsLines|join('\\n') }}{% endif %}</textarea>
+                                  placeholder="Eine Option pro Zeile&#10;z.B.:&#10;MacBook Pro 14\"&#10;MacBook Pro 16\"&#10;ThinkPad X1 (aktiv)">{% if item.options %}{{ item.optionsLines|join('\n') }}{% endif %}</textarea>
                         <div class="form-text">Eine Option pro Zeile. Mit <code>(aktiv)</code> am Ende wird die Option vorausgewählt.</div>
                     </div>
 

--- a/templates/admin/group/add_item.html.twig
+++ b/templates/admin/group/add_item.html.twig
@@ -47,8 +47,8 @@
                                   id="options" 
                                   name="options" 
                                   rows="5"
-                                  placeholder="Eine Option pro Zeile&#10;z.B.:&#10;MacBook Pro 14&quot;&#10;MacBook Pro 16&quot;&#10;ThinkPad X1">{% if item.options %}{{ item.optionsArray|join('\n') }}{% endif %}</textarea>
-                        <div class="form-text">Eine Option pro Zeile</div>
+                                  placeholder="Eine Option pro Zeile&#10;z.B.:&#10;MacBook Pro 14\"&#10;MacBook Pro 16\"&#10;ThinkPad X1 (aktiv)">{% if item.options %}{{ item.optionsLines|join('\\n') }}{% endif %}</textarea>
+                        <div class="form-text">Eine Option pro Zeile. Mit <code>(aktiv)</code> am Ende wird die Option vorausgewählt.</div>
                     </div>
 
                     <div class="mb-4">

--- a/templates/admin/group/edit_item.html.twig
+++ b/templates/admin/group/edit_item.html.twig
@@ -47,7 +47,7 @@
                                   id="options" 
                                   name="options" 
                                   rows="5"
-                                  placeholder="Eine Option pro Zeile&#10;z.B.:&#10;MacBook Pro 14\"&#10;MacBook Pro 16\"&#10;ThinkPad X1 (aktiv)">{% if item.options %}{{ item.optionsLines|join('\\n') }}{% endif %}</textarea>
+                                  placeholder="Eine Option pro Zeile&#10;z.B.:&#10;MacBook Pro 14\"&#10;MacBook Pro 16\"&#10;ThinkPad X1 (aktiv)">{% if item.options %}{{ item.optionsLines|join('\n') }}{% endif %}</textarea>
                         <div class="form-text">Eine Option pro Zeile. Mit <code>(aktiv)</code> am Ende wird die Option vorausgewählt.</div>
                     </div>
 

--- a/templates/admin/group/edit_item.html.twig
+++ b/templates/admin/group/edit_item.html.twig
@@ -47,8 +47,8 @@
                                   id="options" 
                                   name="options" 
                                   rows="5"
-                                  placeholder="Eine Option pro Zeile&#10;z.B.:&#10;MacBook Pro 14&quot;&#10;MacBook Pro 16&quot;&#10;ThinkPad X1">{% if item.options %}{{ item.optionsArray|join('\n') }}{% endif %}</textarea>
-                        <div class="form-text">Eine Option pro Zeile</div>
+                                  placeholder="Eine Option pro Zeile&#10;z.B.:&#10;MacBook Pro 14\"&#10;MacBook Pro 16\"&#10;ThinkPad X1 (aktiv)">{% if item.options %}{{ item.optionsLines|join('\\n') }}{% endif %}</textarea>
+                        <div class="form-text">Eine Option pro Zeile. Mit <code>(aktiv)</code> am Ende wird die Option vorausgewählt.</div>
                     </div>
 
                     <div class="mb-4">

--- a/templates/checklist/form.html.twig
+++ b/templates/checklist/form.html.twig
@@ -46,29 +46,31 @@
                                                       placeholder="Bitte eingeben..."></textarea>
                                         
                                         {% elseif item.type == 'radio' %}
-                                            {% for option in item.optionsArray %}
+                                            {% for option in item.optionsWithActive %}
                                                 <div class="form-check">
-                                                    <input class="form-check-input" 
-                                                           type="radio" 
-                                                           name="item_{{ item.id }}" 
-                                                           value="{{ option }}" 
-                                                           id="item_{{ item.id }}_{{ loop.index }}">
+                                                    <input class="form-check-input"
+                                                           type="radio"
+                                                           name="item_{{ item.id }}"
+                                                           value="{{ option.label }}"
+                                                           id="item_{{ item.id }}_{{ loop.index }}"
+                                                           {% if option.active %}checked{% endif %}>
                                                     <label class="form-check-label" for="item_{{ item.id }}_{{ loop.index }}">
-                                                        {{ option }}
+                                                        {{ option.label }}
                                                     </label>
                                                 </div>
                                             {% endfor %}
-                                        
+
                                         {% elseif item.type == 'checkbox' %}
-                                            {% for option in item.optionsArray %}
+                                            {% for option in item.optionsWithActive %}
                                                 <div class="form-check">
-                                                    <input class="form-check-input" 
-                                                           type="checkbox" 
-                                                           name="item_{{ item.id }}[]" 
-                                                           value="{{ option }}" 
-                                                           id="item_{{ item.id }}_{{ loop.index }}">
+                                                    <input class="form-check-input"
+                                                           type="checkbox"
+                                                           name="item_{{ item.id }}[]"
+                                                           value="{{ option.label }}"
+                                                           id="item_{{ item.id }}_{{ loop.index }}"
+                                                           {% if option.active %}checked{% endif %}>
                                                     <label class="form-check-label" for="item_{{ item.id }}_{{ loop.index }}">
-                                                        {{ option }}
+                                                        {{ option.label }}
                                                     </label>
                                                 </div>
                                             {% endfor %}


### PR DESCRIPTION
## Summary
- allow marking options as active with `(aktiv)`
- support storing active status in `GroupItem`
- parse active options on create/update
- show marker instructions in admin forms
- pre-check active options in checklist form

## Testing
- `composer validate --no-interaction`
- `php -l src/Entity/GroupItem.php`
- `php -l src/Controller/Admin/GroupController.php`
- `php -l templates/admin/group/add_item.html.twig`
- `php -l templates/admin/group/edit_item.html.twig`
- `php -l templates/checklist/form.html.twig`


------
https://chatgpt.com/codex/tasks/task_e_68849ef49b608331a54c668d117fad56