### PR TITLE
Fix newline handling in emails

### DIFF
--- a/src/Service/SubmissionService.php
+++ b/src/Service/SubmissionService.php
@@ -64,6 +64,7 @@ class SubmissionService
                         $output .= "<li><strong>{$itemLabel}:</strong> " . implode(', ', $value) . "</li>\n";
                     } else {
                         // Text und Radio
+                        $value = nl2br($value);
                         $output .= "<li><strong>{$itemLabel}:</strong> {$value}</li>\n";
                     }
                 } else {
@@ -71,6 +72,7 @@ class SubmissionService
                     if (is_array($itemData)) {
                         $output .= "<li><strong>{$itemLabel}:</strong> " . implode(', ', $itemData) . "</li>\n";
                     } else {
+                        $itemData = nl2br($itemData);
                         $output .= "<li><strong>{$itemLabel}:</strong> {$itemData}</li>\n";
                     }
                 }


### PR DESCRIPTION
## Summary
- preserve multiline text field newlines when generating emails

## Testing
- `composer validate --no-interaction`
- `php -l src/Service/SubmissionService.php`

------
https://chatgpt.com/codex/tasks/task_e_6884a685884083319ca38a92d16c31d4