### PR TITLE
Add reply email option to checklists

### DIFF
--- a/README-DEPLOYMENT.md
+++ b/README-DEPLOYMENT.md
@@ -133,6 +133,7 @@ http://localhost:8081/checklist/{stückliste_id}?name=Max%20Mustermann&mitarbeit
 - `{{mitarbeiter_id}}` - Mitarbeiter-ID
 - `{{stückliste}}` - Name der Stückliste
 - `{{auswahl}}` - Strukturierte Ausgabe aller Auswahlen
+- `{{rueckfragen_email}}` - Hinterlegte Rückfragen-Adresse
 
 ## 🛠️ Entwicklung
 

--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ Die folgenden Platzhalter stehen im HTML-Template zur Verfügung:
 | `{{mitarbeiter_id}}` | Mitarbeitenden-ID (aus Link)                          |
 | `{{stückliste}}`  | Name der Stückliste                                      |
 | `{{auswahl}}`     | Strukturierte Ausgabe aller getätigten Auswahlen nach Gruppe |
+| `{{rueckfragen_email}}` | Hinterlegte Rückfragen-Adresse |
 
 ---
 

--- a/migrations/Version20250726000003.php
+++ b/migrations/Version20250726000003.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20250726000003 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add reply_email column to checklists table';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql("ALTER TABLE checklists ADD reply_email VARCHAR(255) DEFAULT NULL");
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql("ALTER TABLE checklists DROP reply_email");
+    }
+}

--- a/src/Controller/Admin/ChecklistController.php
+++ b/src/Controller/Admin/ChecklistController.php
@@ -39,6 +39,12 @@ class ChecklistController extends AbstractController
         if ($request->isMethod('POST')) {
             $checklist->setTitle($request->request->get('title'));
             $checklist->setTargetEmail($request->request->get('target_email'));
+            $reply = trim((string) $request->request->get('reply_email'));
+            if ($reply !== '' && !filter_var($reply, FILTER_VALIDATE_EMAIL)) {
+                $this->addFlash('error', 'Bitte eine gültige Rückfragen-E-Mail eingeben.');
+                return $this->redirectToRoute('admin_checklist_new');
+            }
+            $checklist->setReplyEmail($reply !== '' ? $reply : null);
             $checklist->setEmailTemplate($request->request->get('email_template'));
 
             $this->entityManager->persist($checklist);
@@ -59,6 +65,12 @@ class ChecklistController extends AbstractController
         if ($request->isMethod('POST')) {
             $checklist->setTitle($request->request->get('title'));
             $checklist->setTargetEmail($request->request->get('target_email'));
+            $reply = trim((string) $request->request->get('reply_email'));
+            if ($reply !== '' && !filter_var($reply, FILTER_VALIDATE_EMAIL)) {
+                $this->addFlash('error', 'Bitte eine gültige Rückfragen-E-Mail eingeben.');
+                return $this->redirectToRoute('admin_checklist_edit', ['id' => $checklist->getId()]);
+            }
+            $checklist->setReplyEmail($reply !== '' ? $reply : null);
             $checklist->setEmailTemplate($request->request->get('email_template'));
 
             $this->entityManager->flush();
@@ -138,7 +150,8 @@ class ChecklistController extends AbstractController
                 '{{name}}' => 'Name/Vorname der Person (aus Link)',
                 '{{mitarbeiter_id}}' => 'Mitarbeitenden-ID (aus Link)',
                 '{{stückliste}}' => 'Name der Stückliste',
-                '{{auswahl}}' => 'Strukturierte Ausgabe aller getätigten Auswahlen nach Gruppe'
+                '{{auswahl}}' => 'Strukturierte Ausgabe aller getätigten Auswahlen nach Gruppe',
+                '{{rueckfragen_email}}' => 'Hinterlegte Rückfragen-Adresse'
             ]
         ]);
     }

--- a/src/Entity/Checklist.php
+++ b/src/Entity/Checklist.php
@@ -21,6 +21,9 @@ class Checklist
     #[ORM\Column(type: 'string', length: 255)]
     private ?string $targetEmail = null;
 
+    #[ORM\Column(type: 'string', length: 255, nullable: true)]
+    private ?string $replyEmail = null;
+
     #[ORM\Column(type: 'text', nullable: true)]
     private ?string $emailTemplate = null;
 
@@ -60,6 +63,17 @@ class Checklist
     public function setTargetEmail(string $targetEmail): static
     {
         $this->targetEmail = $targetEmail;
+        return $this;
+    }
+
+    public function getReplyEmail(): ?string
+    {
+        return $this->replyEmail;
+    }
+
+    public function setReplyEmail(?string $replyEmail): static
+    {
+        $this->replyEmail = $replyEmail;
         return $this;
     }
 

--- a/src/Service/EmailService.php
+++ b/src/Service/EmailService.php
@@ -88,7 +88,8 @@ class EmailService
             '{{name}}' => $submission->getName(),
             '{{mitarbeiter_id}}' => $submission->getMitarbeiterId(),
             '{{stückliste}}' => $submission->getChecklist()->getTitle(),
-            '{{auswahl}}' => $auswahl
+            '{{auswahl}}' => $auswahl,
+            '{{rueckfragen_email}}' => $submission->getChecklist()->getReplyEmail() ?? ''
         ];
         
         return str_replace(array_keys($placeholders), array_values($placeholders), $template);
@@ -169,6 +170,7 @@ class EmailService
         
         <h2>Ausgewählte Ausstattung</h2>
         {{auswahl}}
+        <p>Bei Rückfragen zu dieser Bestellung wende dich an {{rueckfragen_email}}.</p>
     </div>
     
     <div class="footer">
@@ -223,8 +225,8 @@ class EmailService
         {{auswahl}}
         
         <p><strong>Nächste Schritte:</strong><br>
-        Deine Angaben werden nun bearbeitet und die entsprechende Ausstattung wird vorbereitet. 
-        Bei Rückfragen werden wir uns bei dir melden.</p>
+        Deine Angaben werden nun bearbeitet und die entsprechende Ausstattung wird vorbereitet.
+        Bei Rückfragen wende dich an {{rueckfragen_email}}.</p>
     </div>
     
     <div class="footer">

--- a/templates/admin/checklist/edit.html.twig
+++ b/templates/admin/checklist/edit.html.twig
@@ -37,14 +37,25 @@
 
                     <div class="mb-3">
                         <label for="target_email" class="form-label">Ziel-E-Mail <span class="text-danger">*</span></label>
-                        <input type="email" 
-                               class="form-control" 
-                               id="target_email" 
-                               name="target_email" 
-                               value="{{ checklist.targetEmail }}" 
+                        <input type="email"
+                               class="form-control"
+                               id="target_email"
+                               name="target_email"
+                               value="{{ checklist.targetEmail }}"
                                required
                                placeholder="it@besteller.local">
                         <div class="form-text">E-Mail-Adresse, an die ausgefüllte Formulare gesendet werden</div>
+                    </div>
+
+                    <div class="mb-3">
+                        <label for="reply_email" class="form-label">Rückfragen-E-Mail</label>
+                        <input type="email"
+                               class="form-control"
+                               id="reply_email"
+                               name="reply_email"
+                               value="{{ checklist.replyEmail }}"
+                               placeholder="kontakt@example.com">
+                        <div class="form-text">Optional: Adresse für Rückfragen</div>
                     </div>
 
 

--- a/templates/admin/checklist/email_template.html.twig
+++ b/templates/admin/checklist/email_template.html.twig
@@ -14,8 +14,9 @@
 
 <div class="alert alert-info">
     <i class="fas fa-info-circle"></i>
-    <strong>Checkliste:</strong> {{ checklist.title }} | 
-    <strong>Ziel-E-Mail:</strong> {{ checklist.targetEmail }}
+    <strong>Checkliste:</strong> {{ checklist.title }} |
+    <strong>Ziel-E-Mail:</strong> {{ checklist.targetEmail }} |
+    <strong>Rückfragen:</strong> {{ checklist.replyEmail ?? '–' }}
 </div>
 
 {% for type, messages in app.flashes %}
@@ -122,6 +123,7 @@
                     <li>E-Mail-Clients unterstützen nur begrenztes CSS</li>
                     <li>Testen Sie das Template mit verschiedenen E-Mail-Clients</li>
                     <li>Der Platzhalter <code>{{ '{{auswahl}}' }}</code> enthält bereits HTML-formatierte Listen</li>
+                    <li>Nutzen Sie <code>{{ '{{rueckfragen_email}}' }}</code> für die Rückfragen-Adresse</li>
                 </ul>
             </div>
         </div>
@@ -207,7 +209,8 @@ function previewTemplate() {
                 <li><strong>Office Suite:</strong> Microsoft Office 365</li>
                 <li><strong>Development Tools:</strong> IntelliJ IDEA, VS Code</li>
             </ul>
-        `);
+        `)
+        .replace(/\{\{rueckfragen_email\}\}/g, 'kontakt@example.com');
     
     const frame = document.getElementById('previewFrame');
     frame.srcdoc = previewContent;

--- a/templates/admin/checklist/new.html.twig
+++ b/templates/admin/checklist/new.html.twig
@@ -32,14 +32,25 @@
 
                     <div class="mb-3">
                         <label for="target_email" class="form-label">Ziel-E-Mail <span class="text-danger">*</span></label>
-                        <input type="email" 
-                               class="form-control" 
-                               id="target_email" 
-                               name="target_email" 
-                               value="{{ checklist.targetEmail ?? '' }}" 
+                        <input type="email"
+                               class="form-control"
+                               id="target_email"
+                               name="target_email"
+                               value="{{ checklist.targetEmail ?? '' }}"
                                required
                                placeholder="it@besteller.local">
                         <div class="form-text">E-Mail-Adresse, an die ausgefüllte Formulare gesendet werden</div>
+                    </div>
+
+                    <div class="mb-3">
+                        <label for="reply_email" class="form-label">Rückfragen-E-Mail</label>
+                        <input type="email"
+                               class="form-control"
+                               id="reply_email"
+                               name="reply_email"
+                               value="{{ checklist.replyEmail ?? '' }}"
+                               placeholder="kontakt@example.com">
+                        <div class="form-text">Optional: Adresse für Rückfragen</div>
                     </div>
 
                     <div class="d-flex gap-2">


### PR DESCRIPTION
## Summary
- add optional `replyEmail` field to Checklist entity
- validate reply email in admin controller
- expose new placeholder `{{rueckfragen_email}}`
- update default email templates
- extend admin templates with field and preview support
- document new placeholder
- add migration for new column

## Testing
- `composer install`
- `php bin/console lint:twig templates/admin/checklist/new.html.twig`


------
https://chatgpt.com/codex/tasks/task_e_6884a5a6e7488331b0909ba90d7e7504