### PR TITLE
Add checklist duplication feature

### DIFF
--- a/config/routes.yaml
+++ b/config/routes.yaml
@@ -55,6 +55,12 @@ admin_checklist_delete:
     requirements:
         id: '\d+'
 
+admin_checklist_duplicate:
+    path: /admin/checklists/{id}/duplicate
+    controller: App\Controller\Admin\ChecklistController::duplicate
+    requirements:
+        id: '\d+'
+
 admin_submissions:
     path: /admin/submissions
     controller: App\Controller\Admin\SubmissionController::index

--- a/templates/admin/checklist/index.html.twig
+++ b/templates/admin/checklist/index.html.twig
@@ -59,12 +59,16 @@
                                            class="btn btn-outline-primary" title="Bearbeiten">
                                             <i class="fas fa-edit"></i>
                                         </a>
-                                        <a href="{{ path('admin_checklist_email_template', {'id': checklist.id}) }}" 
+                                        <a href="{{ path('admin_checklist_email_template', {'id': checklist.id}) }}"
                                            class="btn btn-outline-info" title="E-Mail-Template">
                                             <i class="fas fa-envelope"></i>
                                         </a>
-                                        <button type="button" class="btn btn-outline-danger" 
-                                                data-bs-toggle="modal" 
+                                        <a href="{{ path('admin_checklist_duplicate', {'id': checklist.id}) }}"
+                                           class="btn btn-outline-secondary" title="Duplizieren">
+                                            <i class="fas fa-copy"></i>
+                                        </a>
+                                        <button type="button" class="btn btn-outline-danger"
+                                                data-bs-toggle="modal"
                                                 data-bs-target="#deleteModal{{ checklist.id }}"
                                                 title="Löschen">
                                             <i class="fas fa-trash"></i>


### PR DESCRIPTION
## Summary
- enable duplicating checklists with groups and items
- expose duplication route
- add duplicate button in admin UI

## Testing
- `composer install`
- `php -l src/Controller/Admin/ChecklistController.php`
- `php -l templates/admin/checklist/index.html.twig`
- `php -l config/routes.yaml`


------
https://chatgpt.com/codex/tasks/task_e_6884ab99fa8c8331926b7759f77dda92