### PR TITLE
Fix deleting checklists with submissions

### DIFF
--- a/src/Controller/Admin/ChecklistController.php
+++ b/src/Controller/Admin/ChecklistController.php
@@ -88,6 +88,9 @@ class ChecklistController extends AbstractController
     public function delete(Request $request, Checklist $checklist): Response
     {
         if ($this->isCsrfTokenValid('delete' . $checklist->getId(), $request->request->get('_token'))) {
+            foreach ($checklist->getSubmissions() as $submission) {
+                $this->entityManager->remove($submission);
+            }
             $this->entityManager->remove($checklist);
             $this->entityManager->flush();
 


### PR DESCRIPTION
## Summary
- delete all submissions before removing a checklist

## Testing
- `make test` *(fails: `docker: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_6884adfa22888331ac56d29548beccfe