### PR TITLE
Add sender email setting

### DIFF
--- a/migrations/Version20250726000004.php
+++ b/migrations/Version20250726000004.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20250726000004 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add sender_email column to email_settings table';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql("ALTER TABLE email_settings ADD sender_email VARCHAR(255) NOT NULL DEFAULT 'noreply@besteller.local'");
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql("ALTER TABLE email_settings DROP sender_email");
+    }
+}
+

--- a/src/Controller/Admin/EmailSettingsController.php
+++ b/src/Controller/Admin/EmailSettingsController.php
@@ -32,6 +32,7 @@ class EmailSettingsController extends AbstractController
             $settings->setUsername($request->request->get('username') ?: null);
             $settings->setPassword($request->request->get('password') ?: null);
             $settings->setIgnoreSsl($request->request->getBoolean('ignore_ssl'));
+            $settings->setSenderEmail($request->request->get('sender_email'));
 
             $this->entityManager->flush();
 

--- a/src/Entity/EmailSettings.php
+++ b/src/Entity/EmailSettings.php
@@ -28,6 +28,9 @@ class EmailSettings
     #[ORM\Column(type: 'boolean')]
     private bool $ignoreSsl = false;
 
+    #[ORM\Column(type: 'string', length: 255)]
+    private string $senderEmail = 'noreply@besteller.local';
+
     public function getId(): ?int
     {
         return $this->id;
@@ -85,6 +88,17 @@ class EmailSettings
     public function setIgnoreSsl(bool $ignoreSsl): static
     {
         $this->ignoreSsl = $ignoreSsl;
+        return $this;
+    }
+
+    public function getSenderEmail(): string
+    {
+        return $this->senderEmail;
+    }
+
+    public function setSenderEmail(string $senderEmail): static
+    {
+        $this->senderEmail = $senderEmail;
         return $this;
     }
 }

--- a/src/Service/EmailService.php
+++ b/src/Service/EmailService.php
@@ -47,10 +47,13 @@ class EmailService
         
         // Platzhalter ersetzen
         $emailContent = $this->replacePlaceholders($template, $submission);
-        
+
+        $settings = $this->entityManager->getRepository(EmailSettings::class)->find(1);
+        $from = $settings?->getSenderEmail() ?? 'noreply@besteller.local';
+
         // E-Mail an Zieladresse (interne Bearbeitung)
         $targetEmail = (new Email())
-            ->from('noreply@besteller.local')
+            ->from($from)
             ->to($submission->getChecklist()->getTargetEmail())
             ->subject('Neue Stückliste eingegangen: ' . $submission->getChecklist()->getTitle() . ' - ' . $submission->getName())
             ->html($emailContent);
@@ -62,7 +65,7 @@ class EmailService
         $confirmationContent = $this->replacePlaceholders($confirmationTemplate, $submission);
         
         $managerEmail = (new Email())
-            ->from('noreply@besteller.local')
+            ->from($from)
             ->to($submission->getEmail())
             ->subject('Bestätigung: Die Bestellung wurde erfolgreich übermittelt')
             ->html($confirmationContent);

--- a/templates/admin/email_settings/edit.html.twig
+++ b/templates/admin/email_settings/edit.html.twig
@@ -29,6 +29,10 @@
         <label class="form-label">Passwort (optional)</label>
         <input type="password" name="password" class="form-control" autocomplete="off" value="{{ settings.password }}">
     </div>
+    <div class="mb-3">
+        <label class="form-label">Absenderadresse</label>
+        <input type="email" name="sender_email" class="form-control" required value="{{ settings.senderEmail }}">
+    </div>
     <div class="form-check mb-3">
         <input type="checkbox" id="ignore_ssl" name="ignore_ssl" class="form-check-input" {% if settings.ignoreSsl %}checked{% endif %}>
         <label class="form-check-label" for="ignore_ssl">SSL Zertifikate ignorieren</label>


### PR DESCRIPTION
## Summary
- let admins set a sender address in the mail settings
- use the configured sender address for outgoing emails
- include migration to add new column

## Testing
- `composer install --no-interaction`
- `php -l src/Entity/EmailSettings.php`
- `php -l src/Controller/Admin/EmailSettingsController.php`
- `php -l src/Service/EmailService.php`

------
https://chatgpt.com/codex/tasks/task_e_6884ad58b25083319ad04ca1c5d36e94