### PR TITLE
Implement US-12 checklist link sending

### DIFF
--- a/config/routes.yaml
+++ b/config/routes.yaml
@@ -168,3 +168,16 @@ admin_user_delete:
     methods: [POST]
     requirements:
         id: '\d+'
+
+# Link sending routes
+admin_checklist_send_link:
+    path: /admin/checklists/{id}/send-link
+    controller: App\Controller\Admin\ChecklistController::sendLink
+    requirements:
+        id: '\d+'
+
+admin_checklist_link_template:
+    path: /admin/checklists/{id}/link-template
+    controller: App\Controller\Admin\ChecklistController::linkEmailTemplate
+    requirements:
+        id: '\d+'

--- a/migrations/Version20250726000005.php
+++ b/migrations/Version20250726000005.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20250726000005 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add link_email_template column to checklists';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql("ALTER TABLE checklists ADD link_email_template LONGTEXT DEFAULT NULL");
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql("ALTER TABLE checklists DROP link_email_template");
+    }
+}

--- a/src/Entity/Checklist.php
+++ b/src/Entity/Checklist.php
@@ -27,6 +27,9 @@ class Checklist
     #[ORM\Column(type: 'text', nullable: true)]
     private ?string $emailTemplate = null;
 
+    #[ORM\Column(type: 'text', nullable: true)]
+    private ?string $linkEmailTemplate = null;
+
     #[ORM\OneToMany(mappedBy: 'checklist', targetEntity: ChecklistGroup::class, cascade: ['persist', 'remove'], orphanRemoval: true)]
     private Collection $groups;
 
@@ -85,6 +88,17 @@ class Checklist
     public function setEmailTemplate(?string $emailTemplate): static
     {
         $this->emailTemplate = $emailTemplate;
+        return $this;
+    }
+
+    public function getLinkEmailTemplate(): ?string
+    {
+        return $this->linkEmailTemplate;
+    }
+
+    public function setLinkEmailTemplate(?string $linkEmailTemplate): static
+    {
+        $this->linkEmailTemplate = $linkEmailTemplate;
         return $this;
     }
 

--- a/templates/admin/checklist/edit.html.twig
+++ b/templates/admin/checklist/edit.html.twig
@@ -9,6 +9,12 @@
         <a href="{{ path('admin_checklist_email_template', {'id': checklist.id}) }}" class="btn btn-outline-info">
             <i class="fas fa-envelope"></i> E-Mail-Template verwalten
         </a>
+        <a href="{{ path('admin_checklist_link_template', {'id': checklist.id}) }}" class="btn btn-outline-info">
+            <i class="fas fa-link"></i> Link-Template
+        </a>
+        <a href="{{ path('admin_checklist_send_link', {'id': checklist.id}) }}" class="btn btn-outline-success">
+            <i class="fas fa-paper-plane"></i> Link senden
+        </a>
         <a href="{{ path('admin_checklists') }}" class="btn btn-secondary">
             <i class="fas fa-arrow-left"></i> Zurück zur Übersicht
         </a>

--- a/templates/admin/checklist/index.html.twig
+++ b/templates/admin/checklist/index.html.twig
@@ -63,6 +63,10 @@
                                            class="btn btn-outline-info" title="E-Mail-Template">
                                             <i class="fas fa-envelope"></i>
                                         </a>
+                                        <a href="{{ path('admin_checklist_send_link', {'id': checklist.id}) }}"
+                                           class="btn btn-outline-success" title="Link senden">
+                                            <i class="fas fa-paper-plane"></i>
+                                        </a>
                                         <a href="{{ path('admin_checklist_duplicate', {'id': checklist.id}) }}"
                                            class="btn btn-outline-secondary" title="Duplizieren">
                                             <i class="fas fa-copy"></i>

--- a/templates/admin/checklist/link_template.html.twig
+++ b/templates/admin/checklist/link_template.html.twig
@@ -1,0 +1,35 @@
+{% extends 'admin/base.html.twig' %}
+
+{% block title %}Link-E-Mail-Template: {{ checklist.title }}{% endblock %}
+
+{% block content %}
+<div class="d-flex justify-content-between align-items-center mb-4">
+    <h1>Link-E-Mail-Template</h1>
+    <div class="btn-group">
+        <a href="{{ path('admin_checklist_edit', {'id': checklist.id}) }}" class="btn btn-secondary">
+            <i class="fas fa-arrow-left"></i> Zurück zur Checkliste
+        </a>
+    </div>
+</div>
+
+{% for type, messages in app.flashes %}
+    {% for message in messages %}
+        <div class="alert alert-{{ type == 'error' ? 'danger' : 'success' }} alert-dismissible fade show">
+            {{ message }}
+            <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
+        </div>
+    {% endfor %}
+{% endfor %}
+
+<form method="post" enctype="multipart/form-data">
+    <div class="mb-3">
+        <label class="form-label">HTML-Datei hochladen</label>
+        <input type="file" name="template_file" accept=".html,.htm" class="form-control">
+    </div>
+    <div class="mb-3">
+        <label class="form-label">Template-Inhalt</label>
+        <textarea name="template_content" class="form-control" rows="15">{{ currentTemplate }}</textarea>
+    </div>
+    <button type="submit" class="btn btn-primary">Speichern</button>
+</form>
+{% endblock %}

--- a/templates/admin/checklist/send_link.html.twig
+++ b/templates/admin/checklist/send_link.html.twig
@@ -1,0 +1,41 @@
+{% extends 'admin/base.html.twig' %}
+
+{% block title %}Link versenden: {{ checklist.title }}{% endblock %}
+
+{% block content %}
+<h1>Link zu "{{ checklist.title }}" versenden</h1>
+
+{% for type, messages in app.flashes %}
+    {% for message in messages %}
+        <div class="alert alert-{{ type == 'error' ? 'danger' : 'success' }} alert-dismissible fade show">
+            {{ message }}
+            <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
+        </div>
+    {% endfor %}
+{% endfor %}
+
+<form method="post">
+    <div class="mb-3">
+        <label class="form-label">Empfängername</label>
+        <input type="text" name="recipient_name" class="form-control" required>
+    </div>
+    <div class="mb-3">
+        <label class="form-label">Empfänger E-Mail</label>
+        <input type="email" name="recipient_email" class="form-control" required>
+    </div>
+    <div class="mb-3">
+        <label class="form-label">Personen-ID</label>
+        <input type="text" name="mitarbeiter_id" class="form-control" required>
+    </div>
+    <div class="mb-3">
+        <label class="form-label">Personenname (optional)</label>
+        <input type="text" name="person_name" class="form-control">
+    </div>
+    <div class="mb-3">
+        <label class="form-label">Individuelle Einleitung</label>
+        <textarea name="intro" class="form-control" rows="4"></textarea>
+    </div>
+    <button type="submit" class="btn btn-primary">Senden</button>
+    <a href="{{ path('admin_checklists') }}" class="btn btn-secondary">Abbrechen</a>
+</form>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add `linkEmailTemplate` to `Checklist` entity with migration
- extend `EmailService` to send checklist links via email
- allow admins to edit link email templates and send emails
- add routes and UI templates for the new feature

## Testing
- `composer install --no-interaction`
- `php -l src/Controller/Admin/ChecklistController.php`
- `php -l src/Service/EmailService.php`
- `php -l src/Entity/Checklist.php`


------
https://chatgpt.com/codex/tasks/task_e_6884b4ce73308331b8b7dd1a1169eac3