### PR TITLE
Add parameter docs across controllers

### DIFF
--- a/src/Controller/Admin/ChecklistController.php
+++ b/src/Controller/Admin/ChecklistController.php
@@ -17,6 +17,14 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 #[IsGranted('ROLE_ADMIN')]
 class ChecklistController extends AbstractController
 {
+    /**
+     * Konstruktor für benötigte Services im Admin-Bereich.
+     *
+     * @param EntityManagerInterface $entityManager     Zugriff auf die Datenbank
+     * @param ChecklistRepository    $checklistRepository Repository für Checklisten
+     * @param EmailService           $emailService        Service zum E-Mail-Versand
+     * @param UrlGeneratorInterface  $urlGenerator        Erzeugt absolute Links
+     */
     public function __construct(
         private EntityManagerInterface $entityManager,
         private ChecklistRepository $checklistRepository,
@@ -25,6 +33,11 @@ class ChecklistController extends AbstractController
     ) {
     }
 
+    /**
+     * Listet alle Checklisten auf.
+     *
+     * @return Response Liste aller Checklisten im Admin-Bereich
+     */
     public function index(): Response
     {
         $checklists = $this->checklistRepository->findAll();
@@ -34,6 +47,13 @@ class ChecklistController extends AbstractController
         ]);
     }
 
+    /**
+     * Erstellt eine neue Checkliste.
+     *
+     * @param Request $request Aktuelle HTTP-Anfrage
+     *
+     * @return Response Formular oder Weiterleitung
+     */
     public function new(Request $request): Response
     {
         $checklist = new Checklist();
@@ -62,6 +82,14 @@ class ChecklistController extends AbstractController
         ]);
     }
 
+    /**
+     * Bearbeitet eine bestehende Checkliste.
+     *
+     * @param Request   $request   Aktuelle HTTP-Anfrage
+     * @param Checklist $checklist Die zu bearbeitende Checkliste
+     *
+     * @return Response Formular oder Weiterleitung
+     */
     public function edit(Request $request, Checklist $checklist): Response
     {
         if ($request->isMethod('POST')) {
@@ -87,6 +115,14 @@ class ChecklistController extends AbstractController
         ]);
     }
 
+    /**
+     * Löscht eine Checkliste mitsamt zugehörigen Einsendungen.
+     *
+     * @param Request   $request   Aktuelle HTTP-Anfrage
+     * @param Checklist $checklist Die zu löschende Checkliste
+     *
+     * @return Response Weiterleitung zur Übersicht
+     */
     public function delete(Request $request, Checklist $checklist): Response
     {
         if ($this->isCsrfTokenValid('delete' . $checklist->getId(), $request->request->get('_token'))) {
@@ -102,6 +138,14 @@ class ChecklistController extends AbstractController
         return $this->redirectToRoute('admin_checklists');
     }
 
+    /**
+     * Bearbeitet das E-Mail-Template einer Checkliste.
+     *
+     * @param Request   $request   Aktuelle HTTP-Anfrage
+     * @param Checklist $checklist Die betreffende Checkliste
+     *
+     * @return Response Formularseite
+     */
     public function emailTemplate(Request $request, Checklist $checklist): Response
     {
         // Handle template upload
@@ -161,6 +205,13 @@ class ChecklistController extends AbstractController
         ]);
     }
 
+    /**
+     * Lädt das aktuelle E-Mail-Template als Datei herunter.
+     *
+     * @param Checklist $checklist Die betreffende Checkliste
+     *
+     * @return Response Download der Template-Datei
+     */
     public function downloadEmailTemplate(Checklist $checklist): Response
     {
         $template = $checklist->getEmailTemplate() ?? $this->emailService->getDefaultTemplate();
@@ -177,6 +228,14 @@ class ChecklistController extends AbstractController
         return $response;
     }
 
+    /**
+     * Setzt das E-Mail-Template auf den Standard zurück.
+     *
+     * @param Request   $request   Aktuelle HTTP-Anfrage
+     * @param Checklist $checklist Die betreffende Checkliste
+     *
+     * @return Response Weiterleitung nach dem Zurücksetzen
+     */
     public function resetEmailTemplate(Request $request, Checklist $checklist): Response
     {
         if ($this->isCsrfTokenValid('reset_template' . $checklist->getId(), $request->request->get('_token'))) {
@@ -189,6 +248,13 @@ class ChecklistController extends AbstractController
         return $this->redirectToRoute('admin_checklist_email_template', ['id' => $checklist->getId()]);
     }
 
+    /**
+     * Dupliziert eine vorhandene Checkliste inklusive Gruppen und Items.
+     *
+     * @param Checklist $checklist Die zu duplizierende Checkliste
+     *
+     * @return Response Weiterleitung nach dem Duplizieren
+     */
     public function duplicate(Checklist $checklist): Response
     {
         $newChecklist = new Checklist();
@@ -224,6 +290,14 @@ class ChecklistController extends AbstractController
         return $this->redirectToRoute('admin_checklists');
     }
 
+    /**
+     * Versendet einen personalisierten Link zur Stückliste.
+     *
+     * @param Request   $request   Aktuelle HTTP-Anfrage
+     * @param Checklist $checklist Die betreffende Checkliste
+     *
+     * @return Response Formular oder Weiterleitung
+     */
     public function sendLink(Request $request, Checklist $checklist): Response
     {
         if ($request->isMethod('POST')) {
@@ -264,6 +338,14 @@ class ChecklistController extends AbstractController
         ]);
     }
 
+    /**
+     * Bearbeitet das Template für die Link-E-Mails.
+     *
+     * @param Request   $request   Aktuelle HTTP-Anfrage
+     * @param Checklist $checklist Die betreffende Checkliste
+     *
+     * @return Response Formularseite
+     */
     public function linkEmailTemplate(Request $request, Checklist $checklist): Response
     {
         if ($request->isMethod('POST')) {

--- a/src/Controller/Admin/DashboardController.php
+++ b/src/Controller/Admin/DashboardController.php
@@ -9,10 +9,20 @@ use Symfony\Component\HttpFoundation\Response;
 
 class DashboardController extends AbstractController
 {
+    /**
+     * Konstruktor zum Zugriff auf die Datenbank.
+     *
+     * @param EntityManagerInterface $entityManager Datenbankzugriff
+     */
     public function __construct(private EntityManagerInterface $entityManager)
     {
     }
 
+    /**
+     * Zeigt das Dashboard mit einer Liste aller Checklisten.
+     *
+     * @return Response Anzeige des Dashboards
+     */
     public function index(): Response
     {
         $checklists = $this->entityManager->getRepository(Checklist::class)->findAll();

--- a/src/Controller/Admin/EmailSettingsController.php
+++ b/src/Controller/Admin/EmailSettingsController.php
@@ -12,10 +12,22 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 #[IsGranted('ROLE_ADMIN')]
 class EmailSettingsController extends AbstractController
 {
+    /**
+     * Konstruktor mit EntityManager für den Zugriff auf die E-Mail-Einstellungen.
+     *
+     * @param EntityManagerInterface $entityManager Datenbankzugriff
+     */
     public function __construct(private EntityManagerInterface $entityManager)
     {
     }
 
+    /**
+     * Bearbeitet die globalen E-Mail-Einstellungen.
+     *
+     * @param Request $request Aktuelle HTTP-Anfrage
+     *
+     * @return Response Formularseite für die Einstellungen
+     */
     public function edit(Request $request): Response
     {
         $repository = $this->entityManager->getRepository(EmailSettings::class);

--- a/src/Controller/Admin/GroupController.php
+++ b/src/Controller/Admin/GroupController.php
@@ -14,11 +14,24 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 #[IsGranted('ROLE_ADMIN')]
 class GroupController extends AbstractController
 {
+    /**
+     * Konstruktor mit EntityManager für Gruppenoperationen.
+     *
+     * @param EntityManagerInterface $entityManager Datenbankzugriff
+     */
     public function __construct(
         private EntityManagerInterface $entityManager
     ) {
     }
 
+    /**
+     * Erstellt eine neue Gruppe innerhalb einer Checkliste.
+     *
+     * @param Request   $request   Aktuelle HTTP-Anfrage
+     * @param Checklist $checklist Checkliste, der die Gruppe hinzugefügt wird
+     *
+     * @return Response Formular oder Weiterleitung
+     */
     public function create(Request $request, Checklist $checklist): Response
     {
         $group = new ChecklistGroup();
@@ -43,6 +56,14 @@ class GroupController extends AbstractController
         ]);
     }
 
+    /**
+     * Bearbeitet die Angaben einer Gruppe.
+     *
+     * @param Request       $request Aktuelle HTTP-Anfrage
+     * @param ChecklistGroup $group   Die zu bearbeitende Gruppe
+     *
+     * @return Response Formular oder Weiterleitung
+     */
     public function edit(Request $request, ChecklistGroup $group): Response
     {
         if ($request->isMethod('POST')) {
@@ -62,6 +83,14 @@ class GroupController extends AbstractController
         ]);
     }
 
+    /**
+     * Löscht eine Gruppe aus der Checkliste.
+     *
+     * @param Request       $request Aktuelle HTTP-Anfrage
+     * @param ChecklistGroup $group   Die zu löschende Gruppe
+     *
+     * @return Response Weiterleitung zur Übersicht
+     */
     public function delete(Request $request, ChecklistGroup $group): Response
     {
         $checklistId = $group->getChecklist()->getId();
@@ -76,6 +105,14 @@ class GroupController extends AbstractController
         return $this->redirectToRoute('admin_checklist_edit', ['id' => $checklistId]);
     }
 
+    /**
+     * Fügt einer Gruppe ein neues Element hinzu.
+     *
+     * @param Request       $request Aktuelle HTTP-Anfrage
+     * @param ChecklistGroup $group   Gruppe, der das Element hinzugefügt wird
+     *
+     * @return Response Formular oder Weiterleitung
+     */
     public function addItem(Request $request, ChecklistGroup $group): Response
     {
         $item = new GroupItem();
@@ -115,6 +152,14 @@ class GroupController extends AbstractController
         ]);
     }
 
+    /**
+     * Bearbeitet ein bestehendes Gruppen-Element.
+     *
+     * @param Request  $request Aktuelle HTTP-Anfrage
+     * @param GroupItem $item   Das zu bearbeitende Element
+     *
+     * @return Response Formular oder Weiterleitung
+     */
     public function editItem(Request $request, GroupItem $item): Response
     {
         if ($request->isMethod('POST')) {
@@ -149,6 +194,14 @@ class GroupController extends AbstractController
         ]);
     }
 
+    /**
+     * Entfernt ein Element aus einer Gruppe.
+     *
+     * @param Request  $request Aktuelle HTTP-Anfrage
+     * @param GroupItem $item   Das zu löschende Element
+     *
+     * @return Response Weiterleitung zur Checkliste
+     */
     public function deleteItem(Request $request, GroupItem $item): Response
     {
         $checklistId = $item->getGroup()->getChecklist()->getId();

--- a/src/Controller/Admin/SubmissionController.php
+++ b/src/Controller/Admin/SubmissionController.php
@@ -14,6 +14,13 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 #[IsGranted('ROLE_ADMIN')]
 class SubmissionController extends AbstractController
 {
+    /**
+     * Konstruktor stellt benötigte Repositories bereit.
+     *
+     * @param EntityManagerInterface $entityManager      Datenbankzugriff
+     * @param ChecklistRepository    $checklistRepository Repository für Checklisten
+     * @param SubmissionRepository   $submissionRepository Repository für Einsendungen
+     */
     public function __construct(
         private EntityManagerInterface $entityManager,
         private ChecklistRepository $checklistRepository,
@@ -21,6 +28,11 @@ class SubmissionController extends AbstractController
     ) {
     }
 
+    /**
+     * Übersicht über alle Stücklisten zur Auswahl.
+     *
+     * @return Response Auswahlseite der Stücklisten
+     */
     public function index(): Response
     {
         $checklists = $this->checklistRepository->findAll();
@@ -30,6 +42,14 @@ class SubmissionController extends AbstractController
         ]);
     }
 
+    /**
+     * Zeigt alle Einsendungen einer bestimmten Checkliste an.
+     *
+     * @param Request $request    Aktuelle HTTP-Anfrage
+     * @param int     $checklistId ID der Stückliste
+     *
+     * @return Response Tabelle der Einsendungen
+     */
     public function byChecklist(Request $request, int $checklistId): Response
     {
         $checklist = $this->checklistRepository->find($checklistId);
@@ -47,6 +67,13 @@ class SubmissionController extends AbstractController
         ]);
     }
 
+    /**
+     * Gibt die gespeicherte HTML-E-Mail einer Einsendung aus.
+     *
+     * @param Submission $submission Die gewählte Einsendung
+     *
+     * @return Response HTML-Ausgabe der gespeicherten E-Mail
+     */
     public function viewHtml(Submission $submission): Response
     {
         return new Response($submission->getGeneratedEmail(), 200, [
@@ -54,6 +81,14 @@ class SubmissionController extends AbstractController
         ]);
     }
 
+    /**
+     * Löscht eine Einsendung.
+     *
+     * @param Request    $request    Aktuelle HTTP-Anfrage
+     * @param Submission $submission Die zu löschende Einsendung
+     *
+     * @return Response Weiterleitung zur Einsendungsübersicht
+     */
     public function delete(Request $request, Submission $submission): Response
     {
         $checklistId = $submission->getChecklist()->getId();

--- a/src/Controller/Admin/UserController.php
+++ b/src/Controller/Admin/UserController.php
@@ -13,12 +13,23 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 #[IsGranted('ROLE_ADMIN')]
 class UserController extends AbstractController
 {
+    /**
+     * Konstruktor stellt EntityManager und PasswordHasher bereit.
+     *
+     * @param EntityManagerInterface      $entityManager Datenbankzugriff
+     * @param UserPasswordHasherInterface $passwordHasher Passwort-Hasher
+     */
     public function __construct(
         private EntityManagerInterface $entityManager,
         private UserPasswordHasherInterface $passwordHasher
     ) {
     }
 
+    /**
+     * Zeigt eine Übersicht aller Benutzer.
+     *
+     * @return Response Liste aller Benutzer
+     */
     public function index(): Response
     {
         $users = $this->entityManager->getRepository(User::class)->findAll();
@@ -28,6 +39,13 @@ class UserController extends AbstractController
         ]);
     }
 
+    /**
+     * Legt einen neuen Benutzer an.
+     *
+     * @param Request $request Aktuelle HTTP-Anfrage
+     *
+     * @return Response Formular oder Weiterleitung
+     */
     public function new(Request $request): Response
     {
         if ($request->isMethod('POST')) {
@@ -56,6 +74,14 @@ class UserController extends AbstractController
         return $this->render('admin/user/new.html.twig');
     }
 
+    /**
+     * Bearbeitet einen vorhandenen Benutzer.
+     *
+     * @param Request $request Aktuelle HTTP-Anfrage
+     * @param User    $user    Der zu bearbeitende Benutzer
+     *
+     * @return Response Formular oder Weiterleitung
+     */
     public function edit(Request $request, User $user): Response
     {
         if ($request->isMethod('POST')) {
@@ -91,6 +117,14 @@ class UserController extends AbstractController
         ]);
     }
 
+    /**
+     * Entfernt einen Benutzer.
+     *
+     * @param Request $request Aktuelle HTTP-Anfrage
+     * @param User    $user    Der zu löschende Benutzer
+     *
+     * @return Response Weiterleitung zur Benutzerliste
+     */
     public function delete(Request $request, User $user): Response
     {
         if ($this->isCsrfTokenValid('delete' . $user->getId(), (string) $request->request->get('_token'))) {

--- a/src/Controller/ChecklistController.php
+++ b/src/Controller/ChecklistController.php
@@ -14,12 +14,27 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 class ChecklistController extends AbstractController
 {
+    /**
+     * Konstruktor speichert benötigte Services.
+     *
+     * @param EntityManagerInterface $entityManager  Datenbankzugriff
+     * @param SubmissionService      $submissionService Service zum Sammeln der Formularwerte
+     * @param EmailService           $emailService     Versand der E-Mails
+     */
     public function __construct(
         private EntityManagerInterface $entityManager,
         private SubmissionService $submissionService,
         private EmailService $emailService
     ) {}
 
+    /**
+     * Zeigt eine Stückliste anhand der ID an und prüft Parameter.
+     *
+     * @param int     $id      ID der Stückliste
+     * @param Request $request Aktuelle HTTP-Anfrage
+     *
+     * @return Response HTML-Seite der Stückliste
+     */
     public function show(int $id, Request $request): Response
     {
         $checklist = $this->entityManager->getRepository(Checklist::class)->find($id);
@@ -60,6 +75,14 @@ class ChecklistController extends AbstractController
         ]);
     }
 
+    /**
+     * Verarbeitet eine eingereichte Stückliste und speichert sie.
+     *
+     * @param int     $id      ID der Stückliste
+     * @param Request $request Aktuelle HTTP-Anfrage
+     *
+     * @return Response Erfolgsmeldung nach dem Speichern
+     */
     public function submit(int $id, Request $request): Response
     {
         $checklist = $this->entityManager->getRepository(Checklist::class)->find($id);
@@ -117,6 +140,13 @@ class ChecklistController extends AbstractController
         ]);
     }
 
+    /**
+     * Zeigt das Formular zur Stückliste und verarbeitet Eingaben.
+     *
+     * @param Request $request Aktuelle HTTP-Anfrage
+     *
+     * @return Response Formularseite oder Erfolgsmeldung
+     */
     public function form(Request $request): Response
     {
         // Parameter aus URL prüfen
@@ -207,6 +237,14 @@ class ChecklistController extends AbstractController
         ]);
     }
 
+    /**
+     * Sammelt alle Formulardaten aus der Anfrage.
+     *
+     * @param Request   $request   Aktuelle HTTP-Anfrage
+     * @param Checklist $checklist Die zu verarbeitende Stückliste
+     *
+     * @return array Aufbereitete Formulardaten
+     */
     private function collectFormData(Request $request, Checklist $checklist): array
     {
         $formData = [];

--- a/src/Controller/HomeController.php
+++ b/src/Controller/HomeController.php
@@ -8,6 +8,11 @@ use Symfony\Component\Routing\Annotation\Route;
 
 class HomeController extends AbstractController
 {
+    /**
+     * Zeigt die Startseite an.
+     *
+     * @return Response Antwort mit der gerenderten Startseite
+     */
     public function index(): Response
     {
         return $this->render('home/index.html.twig');

--- a/src/Controller/SecurityController.php
+++ b/src/Controller/SecurityController.php
@@ -9,6 +9,14 @@ use Symfony\Component\Security\Http\Authentication\AuthenticationUtils;
 
 class SecurityController extends AbstractController
 {
+    /**
+     * Zeigt das Login-Formular und verarbeitet Login-Fehler.
+     *
+     * @param AuthenticationUtils $authenticationUtils Hilfsobjekt für Authentifizierung
+     * @param Request $request                          Aktuelle HTTP-Anfrage
+     *
+     * @return Response Login-Seite oder Weiterleitung
+     */
     public function login(AuthenticationUtils $authenticationUtils, Request $request): Response
     {
         if ($this->getUser()) {
@@ -34,6 +42,11 @@ class SecurityController extends AbstractController
         ]);
     }
 
+    /**
+     * Wird von der Firewall abgefangen und führt den Logout aus.
+     *
+     * @return void
+     */
     public function logout(): void
     {
         throw new \LogicException('This method can be blank - it will be intercepted by the logout key on your firewall.');


### PR DESCRIPTION
## Summary
- expand German PHPDoc comments to include parameter explanations

## Testing
- `php -l src/Controller/Admin/ChecklistController.php`
- `php -l src/Controller/Admin/DashboardController.php`
- `php -l src/Controller/Admin/EmailSettingsController.php`
- `php -l src/Controller/Admin/GroupController.php`
- `php -l src/Controller/Admin/SubmissionController.php`
- `php -l src/Controller/Admin/UserController.php`
- `php -l src/Controller/ChecklistController.php`
- `php -l src/Controller/HomeController.php`
- `php -l src/Controller/SecurityController.php`
- `make test` *(fails: `docker` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6884b84bedb883319c47465789453d3d