### PR TITLE
Add German docblocks

### DIFF
--- a/src/Command/ChangePasswordCommand.php
+++ b/src/Command/ChangePasswordCommand.php
@@ -18,6 +18,10 @@ use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
 )]
 class ChangePasswordCommand extends Command
 {
+    /**
+     * @param EntityManagerInterface      $entityManager Datenbankzugriff
+     * @param UserPasswordHasherInterface $passwordHasher Passwort-Hasher
+     */
     public function __construct(
         private EntityManagerInterface $entityManager,
         private UserPasswordHasherInterface $passwordHasher
@@ -25,14 +29,24 @@ class ChangePasswordCommand extends Command
         parent::__construct();
     }
 
+    /**
+     * Legt die benötigten Argumente für den Befehl fest.
+     */
     protected function configure(): void
     {
         $this
             ->addArgument('email', InputArgument::REQUIRED, 'E-Mail-Adresse des Benutzers')
-            ->addArgument('password', InputArgument::REQUIRED, 'Neues Passwort (mindestens 16 Zeichen)')
-        ;
+            ->addArgument('password', InputArgument::REQUIRED, 'Neues Passwort (mindestens 16 Zeichen)');
     }
 
+    /**
+     * Ändert das Passwort eines vorhandenen Benutzers.
+     *
+     * @param InputInterface  $input  Eingabedaten der Konsole
+     * @param OutputInterface $output Ausgabeschnittstelle
+     *
+     * @return int Statuscode
+     */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $io = new SymfonyStyle($input, $output);

--- a/src/Command/CreateUserCommand.php
+++ b/src/Command/CreateUserCommand.php
@@ -18,6 +18,10 @@ use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
 )]
 class CreateUserCommand extends Command
 {
+    /**
+     * @param EntityManagerInterface      $entityManager Datenbankzugriff
+     * @param UserPasswordHasherInterface $passwordHasher Dienst zum Hashen des Passworts
+     */
     public function __construct(
         private EntityManagerInterface $entityManager,
         private UserPasswordHasherInterface $passwordHasher
@@ -25,14 +29,24 @@ class CreateUserCommand extends Command
         parent::__construct();
     }
 
+    /**
+     * Definiert die erwarteten Argumente für den Konsolenbefehl.
+     */
     protected function configure(): void
     {
         $this
             ->addArgument('email', InputArgument::REQUIRED, 'E-Mail-Adresse des Benutzers')
-            ->addArgument('password', InputArgument::REQUIRED, 'Passwort (mindestens 16 Zeichen)')
-        ;
+            ->addArgument('password', InputArgument::REQUIRED, 'Passwort (mindestens 16 Zeichen)');
     }
 
+    /**
+     * Führt den Befehl aus und erstellt den Benutzer.
+     *
+     * @param InputInterface  $input  Eingabeparameter der Konsole
+     * @param OutputInterface $output Ausgabeschnittstelle
+     *
+     * @return int Statuscode
+     */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $io = new SymfonyStyle($input, $output);

--- a/src/Service/SubmissionService.php
+++ b/src/Service/SubmissionService.php
@@ -8,6 +8,14 @@ use Symfony\Component\HttpFoundation\Request;
 
 class SubmissionService
 {
+    /**
+     * Sammelt die vom Nutzer übermittelten Daten einer Stückliste.
+     *
+     * @param Checklist $checklist Die aktuelle Stückliste
+     * @param Request   $request   Der HTTP-Request mit den Formdaten
+     *
+     * @return array Die strukturierten Bestelldaten
+     */
     public function collectSubmissionData(Checklist $checklist, Request $request): array
     {
         $data = [];
@@ -48,6 +56,13 @@ class SubmissionService
         return $data;
     }
     
+    /**
+     * Formatiert übermittelte Daten für den Versand per E-Mail.
+     *
+     * @param array $data Die zuvor gesammelten Bestelldaten
+     *
+     * @return string HTML-Markup für die E-Mail
+     */
     public function formatSubmissionForEmail(array $data): string
     {
         $output = '';


### PR DESCRIPTION
## Summary
- comment service methods in German
- document parameters for commands

## Testing
- `composer validate --no-interaction`
- `php -l src/Service/SubmissionService.php`
- `php -l src/Service/EmailService.php`
- `php -l src/Command/CreateUserCommand.php`
- `php -l src/Command/ChangePasswordCommand.php`


------
https://chatgpt.com/codex/tasks/task_e_6884d844bee4833185ce0fd37596da1c