### PR TITLE
Refactor email template action

### DIFF
--- a/src/Controller/Admin/ChecklistController.php
+++ b/src/Controller/Admin/ChecklistController.php
@@ -378,7 +378,7 @@ class ChecklistController extends AbstractController
             $extension = strtolower($uploadedFile->getClientOriginalExtension());
 
             if (!in_array($mimeType, ['text/html', 'text/plain']) && !in_array($extension, ['html', 'htm'])) {
-                $this->addFlash('error', 'Bitte laden Sie nur HTML-Dateien hoch (.html oder .htm).');
+                $this->addFlash('error', 'Bitte laden Sie nur HTML-Dateien hoch (.html oder .htm). Detektierter MIME-Typ: ' . $mimeType . '.');
                 return $this->redirectToRoute($route, ['id' => $checklist->getId()]);
             }
 

--- a/src/Controller/Admin/ChecklistController.php
+++ b/src/Controller/Admin/ChecklistController.php
@@ -148,61 +148,32 @@ class ChecklistController extends AbstractController
      */
     public function emailTemplate(Request $request, Checklist $checklist): Response
     {
-        // Handle template upload
-        if ($request->isMethod('POST')) {
-            /** @var UploadedFile $uploadedFile */
-            $uploadedFile = $request->files->get('template_file');
-            $templateContent = $request->request->get('template_content');
-            
-            if ($uploadedFile) {
-                // Validate file type
-                $mimeType = $uploadedFile->getMimeType();
-                $extension = strtolower($uploadedFile->getClientOriginalExtension());
-                
-                if (!in_array($mimeType, ['text/html', 'text/plain']) && 
-                    !in_array($extension, ['html', 'htm'])) {
-                    $this->addFlash('error', 'Bitte laden Sie nur HTML-Dateien hoch (.html oder .htm). Erkannter Dateityp: ' . $mimeType);
-                    return $this->redirectToRoute('admin_checklist_email_template', ['id' => $checklist->getId()]);
-                }
-                
-                // Check file size (max 1MB)
-                if ($uploadedFile->getSize() > 1024 * 1024) {
-                    $this->addFlash('error', 'Die Datei ist zu groß. Maximale Größe: 1MB.');
-                    return $this->redirectToRoute('admin_checklist_email_template', ['id' => $checklist->getId()]);
-                }
-                
-                // Read file content
-                $templateContent = file_get_contents($uploadedFile->getPathname());
-                
-                if ($templateContent === false) {
-                    $this->addFlash('error', 'Die hochgeladene Datei konnte nicht gelesen werden.');
-                    return $this->redirectToRoute('admin_checklist_email_template', ['id' => $checklist->getId()]);
-                }
-            }
-            
-            if ($templateContent) {
-                $checklist->setEmailTemplate($templateContent);
-                $this->entityManager->flush();
-                
-                $this->addFlash('success', 'E-Mail-Template wurde erfolgreich aktualisiert.');
-            } else {
-                $this->addFlash('error', 'Bitte geben Sie Template-Inhalt ein oder laden eine Datei hoch.');
-            }
-            
-            return $this->redirectToRoute('admin_checklist_email_template', ['id' => $checklist->getId()]);
+        if (!$request->isMethod('POST')) {
+            return $this->render('admin/checklist/email_template.html.twig', [
+                'checklist' => $checklist,
+                'currentTemplate' => $checklist->getEmailTemplate() ?? $this->emailService->getDefaultTemplate(),
+                'placeholders' => [
+                    '{{name}}' => 'Name/Vorname der Person (aus Link)',
+                    '{{mitarbeiter_id}}' => 'Mitarbeitenden-ID (aus Link)',
+                    '{{stückliste}}' => 'Name der Stückliste',
+                    '{{auswahl}}' => 'Strukturierte Ausgabe aller getätigten Auswahlen nach Gruppe',
+                    '{{rueckfragen_email}}' => 'Hinterlegte Rückfragen-Adresse',
+                ],
+            ]);
         }
 
-        return $this->render('admin/checklist/email_template.html.twig', [
-            'checklist' => $checklist,
-            'currentTemplate' => $checklist->getEmailTemplate() ?? $this->emailService->getDefaultTemplate(),
-            'placeholders' => [
-                '{{name}}' => 'Name/Vorname der Person (aus Link)',
-                '{{mitarbeiter_id}}' => 'Mitarbeitenden-ID (aus Link)',
-                '{{stückliste}}' => 'Name der Stückliste',
-                '{{auswahl}}' => 'Strukturierte Ausgabe aller getätigten Auswahlen nach Gruppe',
-                '{{rueckfragen_email}}' => 'Hinterlegte Rückfragen-Adresse'
-            ]
-        ]);
+        $result = $this->extractTemplateContent($request, $checklist, 'admin_checklist_email_template');
+
+        if ($result instanceof Response) {
+            return $result;
+        }
+
+        $checklist->setEmailTemplate($result);
+        $this->entityManager->flush();
+
+        $this->addFlash('success', 'E-Mail-Template wurde erfolgreich aktualisiert.');
+
+        return $this->redirectToRoute('admin_checklist_email_template', ['id' => $checklist->getId()]);
     }
 
     /**
@@ -391,5 +362,44 @@ class ChecklistController extends AbstractController
             'checklist' => $checklist,
             'currentTemplate' => $checklist->getLinkEmailTemplate() ?? $this->emailService->getDefaultLinkTemplate(),
         ]);
+    }
+
+    /**
+     * Validiert Uploads und gibt den Template-Inhalt zurück oder eine Response im Fehlerfall.
+     */
+    private function extractTemplateContent(Request $request, Checklist $checklist, string $route): Response|string
+    {
+        /** @var UploadedFile|null $uploadedFile */
+        $uploadedFile = $request->files->get('template_file');
+        $templateContent = $request->request->get('template_content');
+
+        if ($uploadedFile) {
+            $mimeType = $uploadedFile->getMimeType();
+            $extension = strtolower($uploadedFile->getClientOriginalExtension());
+
+            if (!in_array($mimeType, ['text/html', 'text/plain']) && !in_array($extension, ['html', 'htm'])) {
+                $this->addFlash('error', 'Bitte laden Sie nur HTML-Dateien hoch (.html oder .htm).');
+                return $this->redirectToRoute($route, ['id' => $checklist->getId()]);
+            }
+
+            if ($uploadedFile->getSize() > 1024 * 1024) {
+                $this->addFlash('error', 'Die Datei ist zu groß. Maximale Größe: 1MB.');
+                return $this->redirectToRoute($route, ['id' => $checklist->getId()]);
+            }
+
+            $templateContent = file_get_contents($uploadedFile->getPathname());
+
+            if ($templateContent === false) {
+                $this->addFlash('error', 'Die hochgeladene Datei konnte nicht gelesen werden.');
+                return $this->redirectToRoute($route, ['id' => $checklist->getId()]);
+            }
+        }
+
+        if (!$templateContent) {
+            $this->addFlash('error', 'Bitte geben Sie Template-Inhalt ein oder laden eine Datei hoch.');
+            return $this->redirectToRoute($route, ['id' => $checklist->getId()]);
+        }
+
+        return $templateContent;
     }
 }


### PR DESCRIPTION
## Summary
- simplify `emailTemplate()` by using early return
- extract new `extractTemplateContent()` helper to validate uploads

## Testing
- `php -l src/Controller/Admin/ChecklistController.php`
- `find src/Controller -name '*.php' -print0 | xargs -0 -n1 php -l`
- `~/.local/share/mise/installs/php/8.4.10/.composer/vendor/bin/pdepend --summary-xml=/tmp/summary_after.xml src/Controller`

------
https://chatgpt.com/codex/tasks/task_e_6884fb07ebb4833189f660a4560d0649