### PR TITLE
Extract checklist duplication to service

### DIFF
--- a/src/Service/ChecklistDuplicationService.php
+++ b/src/Service/ChecklistDuplicationService.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Service;
+
+use App\Entity\Checklist;
+use App\Entity\ChecklistGroup;
+use App\Entity\GroupItem;
+use Doctrine\ORM\EntityManagerInterface;
+
+class ChecklistDuplicationService
+{
+    public function __construct(private EntityManagerInterface $entityManager)
+    {
+    }
+
+    /**
+     * Dupliziert eine vorhandene Checkliste inklusive Gruppen und Items.
+     */
+    public function duplicate(Checklist $checklist): Checklist
+    {
+        $newChecklist = new Checklist();
+        $newChecklist->setTitle('Duplikat von ' . $checklist->getTitle());
+        $newChecklist->setTargetEmail($checklist->getTargetEmail());
+        $newChecklist->setReplyEmail($checklist->getReplyEmail());
+        $newChecklist->setEmailTemplate($checklist->getEmailTemplate());
+
+        foreach ($checklist->getGroups() as $group) {
+            $newGroup = new ChecklistGroup();
+            $newGroup->setTitle($group->getTitle());
+            $newGroup->setDescription($group->getDescription());
+            $newGroup->setSortOrder($group->getSortOrder());
+            $newGroup->setChecklist($newChecklist);
+
+            foreach ($group->getItems() as $item) {
+                $newItem = new GroupItem();
+                $newItem->setLabel($item->getLabel());
+                $newItem->setType($item->getType());
+                $newItem->setOptions($item->getOptions());
+                $newItem->setSortOrder($item->getSortOrder());
+                $newGroup->addItem($newItem);
+            }
+
+            $newChecklist->addGroup($newGroup);
+        }
+
+        $this->entityManager->persist($newChecklist);
+        $this->entityManager->flush();
+
+        return $newChecklist;
+    }
+}


### PR DESCRIPTION
## Summary
- add `ChecklistDuplicationService`
- inject and use service in admin controller

## Testing
- `php -l src/Service/ChecklistDuplicationService.php`
- `php -l src/Controller/Admin/ChecklistController.php`
- `composer validate --no-check-all`

------
https://chatgpt.com/codex/tasks/task_e_6885057bcc748331bad9deabdbbd8e3a