### PR TITLE
Allow dev/prod modes in Makefile deploy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,16 @@
 
 .PHONY: help build start stop restart install migrate clear-cache test
 
+# Default environment is development. Override by running `make <target> ENV=prod`
+ENV ?= dev
+ifeq ($(ENV),prod)
+APP_DEBUG=0
+else
+APP_DEBUG=1
+endif
+export APP_ENV=$(ENV)
+export APP_DEBUG
+
 help: ## Zeigt diese Hilfe an
 	@echo "Verfügbare Befehle:"
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'
@@ -16,7 +26,7 @@ build: ## Baut Docker Container
 	docker compose build
 
 start: ## Startet die Anwendung
-	docker compose up -d
+	APP_ENV=$(APP_ENV) APP_DEBUG=$(APP_DEBUG) docker compose up -d
 
 stop: ## Stoppt die Anwendung
 	docker compose down
@@ -25,7 +35,7 @@ restart: ## Neustart der Anwendung
 	docker compose restart
 
 install: ## Installiert Symfony und Abhängigkeiten
-	docker compose exec php composer install
+	docker compose exec php composer install $(if $(filter $(ENV),prod),--no-dev --optimize-autoloader,)
 	docker compose exec php bin/console doctrine:migrations:migrate --no-interaction
 
 migrate: ## Führt Datenbank-Migrationen aus

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,11 +21,11 @@ services:
     volumes:
       - ./:/var/www/html
     environment:
-      - APP_ENV=dev
-      - APP_DEBUG=1
-      - APP_SECRET=dev-secret-key-for-development-only
-      - DATABASE_URL=mysql://besteller:besteller@db:3306/besteller?serverVersion=10.11.2-MariaDB&charset=utf8mb4
-      - MAILER_DSN=smtp://mailhog:1025
+      APP_ENV: ${APP_ENV:-dev}
+      APP_DEBUG: ${APP_DEBUG:-1}
+      APP_SECRET: ${APP_SECRET:-dev-secret-key-for-development-only}
+      DATABASE_URL: ${DATABASE_URL:-mysql://besteller:besteller@db:3306/besteller?serverVersion=10.11.2-MariaDB&charset=utf8mb4}
+      MAILER_DSN: ${MAILER_DSN:-smtp://mailhog:1025}
     depends_on:
       - db
     networks:


### PR DESCRIPTION
## Summary
- make `deploy` choose environment via `ENV` variable
- pass `APP_ENV` and `APP_DEBUG` to Docker Compose
- install dev dependencies only in development
- parameterize environment variables in `docker-compose.yml`

## Testing
- `make test` *(fails: docker not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68850804c36c83318965fa54d6e54ac3