### PR TITLE
Add PHPStan support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,16 @@ test: ## Führt Tests aus
 	docker compose exec php bin/phpunit
 
 phpstan: ## Führt statische Analyse mit PHPStan aus
-	docker compose exec php vendor/bin/phpstan analyse
+	docker compose exec php vendor/bin/phpstan analyse --memory-limit=512M
+
+phpstan-fix: ## Führt PHPStan mit höherem Memory-Limit aus (1GB)
+	docker compose exec php vendor/bin/phpstan analyse --memory-limit=1G
+
+phpstan-baseline: ## Erstellt eine PHPStan Baseline für bestehende Fehler
+	docker compose exec php vendor/bin/phpstan analyse --memory-limit=512M --generate-baseline
+
+phpstan-clear: ## Löscht PHPStan Cache
+	docker compose exec php vendor/bin/phpstan clear-result-cache
 
 logs: ## Zeigt Container Logs
 	docker compose logs -f

--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,9 @@ clear-cache: ## Löscht den Symfony Cache
 test: ## Führt Tests aus
 	docker compose exec php bin/phpunit
 
+phpstan: ## Führt statische Analyse mit PHPStan aus
+	docker compose exec php vendor/bin/phpstan analyse
+
 logs: ## Zeigt Container Logs
 	docker compose logs -f
 

--- a/README-DEPLOYMENT.md
+++ b/README-DEPLOYMENT.md
@@ -54,6 +54,7 @@ make logs           # Zeigt Logs
 make shell          # Öffnet Shell im PHP Container
 make migrate        # Führt Migrationen aus
 make clear-cache    # Löscht Symfony Cache
+make phpstan        # Führt statische Analyse aus
 ```
 
 ### Benutzerverwaltung

--- a/composer.json
+++ b/composer.json
@@ -73,6 +73,7 @@
         }
     },
     "require-dev": {
+        "phpstan/phpstan": "^2.1",
         "symfony/maker-bundle": "^1.0",
         "symfony/web-profiler-bundle": "7.3.*"
     }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "96c95855d1f08e4f2b075af9dd842152",
+    "content-hash": "5534f372bbb04843b220612c7e6cac50",
     "packages": [
         {
             "name": "doctrine/cache",
@@ -5931,6 +5931,64 @@
                 "source": "https://github.com/nikic/PHP-Parser/tree/v5.5.0"
             },
             "time": "2025-05-31T08:24:38+00:00"
+        },
+        {
+            "name": "phpstan/phpstan",
+            "version": "2.1.19",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpstan.git",
+                "reference": "473a8c30e450d87099f76313edcbb90852f9afdf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/473a8c30e450d87099f76313edcbb90852f9afdf",
+                "reference": "473a8c30e450d87099f76313edcbb90852f9afdf",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4|^8.0"
+            },
+            "conflict": {
+                "phpstan/phpstan-shim": "*"
+            },
+            "bin": [
+                "phpstan",
+                "phpstan.phar"
+            ],
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPStan - PHP Static Analysis Tool",
+            "keywords": [
+                "dev",
+                "static analysis"
+            ],
+            "support": {
+                "docs": "https://phpstan.org/user-guide/getting-started",
+                "forum": "https://github.com/phpstan/phpstan/discussions",
+                "issues": "https://github.com/phpstan/phpstan/issues",
+                "security": "https://github.com/phpstan/phpstan/security/policy",
+                "source": "https://github.com/phpstan/phpstan-src"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/ondrejmirtes",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/phpstan",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-07-21T19:58:24+00:00"
         },
         {
             "name": "symfony/maker-bundle",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,7 @@
+includes:
+    - vendor/phpstan/phpstan/conf/bleedingEdge.neon
+
+parameters:
+    level: max
+    paths:
+        - src

--- a/symfony.lock
+++ b/symfony.lock
@@ -35,6 +35,15 @@
             "migrations/.gitignore"
         ]
     },
+    "phpstan/phpstan": {
+        "version": "2.1",
+        "recipe": {
+            "repo": "github.com/symfony/recipes-contrib",
+            "branch": "main",
+            "version": "1.0",
+            "ref": "5e490cc197fb6bb1ae22e5abbc531ddc633b6767"
+        }
+    },
     "symfony/console": {
         "version": "7.3",
         "recipe": {


### PR DESCRIPTION
## Summary
- add PHPStan as a dev dependency and config
- allow running PHPStan via `make phpstan`
- document PHPStan Makefile target

## Testing
- `vendor/bin/phpstan --no-progress --error-format=table --memory-limit=512M`
- `make phpstan` *(fails: docker not found)*

------
https://chatgpt.com/codex/tasks/task_e_68851beb4d1083319ace063806a03497