### PR TITLE
Fix ChangePasswordCommand argument types

### DIFF
--- a/src/Command/ChangePasswordCommand.php
+++ b/src/Command/ChangePasswordCommand.php
@@ -51,7 +51,16 @@ class ChangePasswordCommand extends Command
     {
         $io = new SymfonyStyle($input, $output);
         $email = $input->getArgument('email');
+        if (!is_string($email)) {
+            $io->error('Ungültige E-Mail-Adresse.');
+            return Command::FAILURE;
+        }
+
         $password = $input->getArgument('password');
+        if (!is_string($password)) {
+            $io->error('Ungültiges Passwort.');
+            return Command::FAILURE;
+        }
 
         // Passwort-Validierung
         if (strlen($password) < 16) {


### PR DESCRIPTION
## Summary
- validate email and password arguments before string operations

## Testing
- `./vendor/bin/phpstan analyze src/Command/ChangePasswordCommand.php --no-progress --memory-limit=512M`

------
https://chatgpt.com/codex/tasks/task_e_68851f61d104833184485d508aec2b8f