### PR TITLE
Fix CreateUserCommand type checks

### DIFF
--- a/src/Command/CreateUserCommand.php
+++ b/src/Command/CreateUserCommand.php
@@ -53,6 +53,11 @@ class CreateUserCommand extends Command
         $email = $input->getArgument('email');
         $password = $input->getArgument('password');
 
+        if (!is_string($email) || !is_string($password)) {
+            $io->error('Ungültige Eingabewerte.');
+            return Command::FAILURE;
+        }
+
         // Passwort-Validierung
         if (strlen($password) < 16) {
             $io->error('Das Passwort muss mindestens 16 Zeichen lang sein.');


### PR DESCRIPTION
## Summary
- ensure console arguments are strings before using them
- run phpstan to confirm no type errors

## Testing
- `composer install --no-interaction`
- `./vendor/bin/phpstan analyze src/Command/CreateUserCommand.php`

------
https://chatgpt.com/codex/tasks/task_e_6885227d61ac8331a42da599ef0ba869