### PR TITLE
Fix some PHPStan issues

### DIFF
--- a/src/Controller/Admin/EmailSettingsController.php
+++ b/src/Controller/Admin/EmailSettingsController.php
@@ -39,12 +39,17 @@ class EmailSettingsController extends AbstractController
         }
 
         if ($request->isMethod('POST')) {
-            $settings->setHost($request->request->get('host'));
-            $settings->setPort((int) $request->request->get('port'));
-            $settings->setUsername($request->request->get('username') ?: null);
-            $settings->setPassword($request->request->get('password') ?: null);
+            $settings->setHost($request->request->getString('host'));
+            $settings->setPort($request->request->getInt('port'));
+
+            $username = trim($request->request->getString('username', ''));
+            $settings->setUsername($username === '' ? null : $username);
+
+            $password = trim($request->request->getString('password', ''));
+            $settings->setPassword($password === '' ? null : $password);
+
             $settings->setIgnoreSsl($request->request->getBoolean('ignore_ssl'));
-            $settings->setSenderEmail($request->request->get('sender_email'));
+            $settings->setSenderEmail($request->request->getString('sender_email'));
 
             $this->entityManager->flush();
 

--- a/src/Controller/Admin/GroupController.php
+++ b/src/Controller/Admin/GroupController.php
@@ -187,7 +187,7 @@ class GroupController extends AbstractController
                     $active = false;
                     if (preg_match('/\(aktiv\)$/i', $line)) {
                         $active = true;
-                        $line = trim((string) preg_replace('/\(aktiv\)$/i', '', $line));
+                        $line = trim(preg_replace('/\(aktiv\)$/i', '', $line) ?? $line);
                     }
                     $options[] = ['label' => $line, 'active' => $active];
                 }

--- a/src/Controller/Admin/GroupController.php
+++ b/src/Controller/Admin/GroupController.php
@@ -138,7 +138,7 @@ class GroupController extends AbstractController
                     $active = false;
                     if (preg_match('/\(aktiv\)$/i', $line)) {
                         $active = true;
-                        $line = trim((string) preg_replace('/\(aktiv\)$/i', '', $line));
+                        $line = trim(preg_replace('/\(aktiv\)$/i', '', $line) ?? $line);
                     }
                     $options[] = ['label' => $line, 'active' => $active];
                 }

--- a/src/Controller/ChecklistController.php
+++ b/src/Controller/ChecklistController.php
@@ -37,6 +37,9 @@ class ChecklistController extends AbstractController
         return $checklist;
     }
 
+    /**
+     * @return list{string, string, string}
+     */
     private function getRequestValues(Request $request, bool $useQuery = true): array
     {
         $source = $useQuery ? $request->query : $request->request;

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -18,11 +18,14 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     #[ORM\Column(type: 'string', length: 180, unique: true)]
     private ?string $email = null;
 
+    /**
+     * @var list<string>
+     */
     #[ORM\Column(type: 'json')]
     private array $roles = [];
 
     #[ORM\Column(type: 'string')]
-    private ?string $password = null;
+    private string $password = '';
 
     public function getId(): ?int
     {
@@ -51,6 +54,9 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     /**
      * @see UserInterface
      */
+    /**
+     * @return list<string>
+     */
     public function getRoles(): array
     {
         $roles = $this->roles;
@@ -60,6 +66,9 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
         return array_unique($roles);
     }
 
+    /**
+     * @param list<string> $roles
+     */
     public function setRoles(array $roles): static
     {
         $this->roles = $roles;

--- a/src/Repository/ChecklistRepository.php
+++ b/src/Repository/ChecklistRepository.php
@@ -8,6 +8,8 @@ use Doctrine\Persistence\ManagerRegistry;
 
 /**
  * Repository für Checklist Entity
+ *
+ * @extends ServiceEntityRepository<Checklist>
  */
 class ChecklistRepository extends ServiceEntityRepository
 {
@@ -18,6 +20,9 @@ class ChecklistRepository extends ServiceEntityRepository
 
     /**
      * Alle aktiven Checklisten finden
+     */
+    /**
+     * @return list<Checklist>
      */
     public function findAll(): array
     {
@@ -32,6 +37,8 @@ class ChecklistRepository extends ServiceEntityRepository
      */
     public function find($id, $lockMode = null, $lockVersion = null): ?Checklist
     {
-        return parent::find($id, $lockMode, $lockVersion);
+        /** @var Checklist|null $entity */
+        $entity = parent::find($id, $lockMode, $lockVersion);
+        return $entity;
     }
 }

--- a/src/Repository/SubmissionRepository.php
+++ b/src/Repository/SubmissionRepository.php
@@ -18,7 +18,7 @@ class SubmissionRepository extends ServiceEntityRepository
     }
 
     /**
-     * @return Submission[]
+     * @return list<Submission>
      */
     public function findByChecklist(Checklist $checklist, ?string $search = null): array
     {

--- a/src/Service/ChecklistDuplicationService.php
+++ b/src/Service/ChecklistDuplicationService.php
@@ -20,21 +20,21 @@ class ChecklistDuplicationService
     {
         $newChecklist = new Checklist();
         $newChecklist->setTitle('Duplikat von ' . $checklist->getTitle());
-        $newChecklist->setTargetEmail($checklist->getTargetEmail());
+        $newChecklist->setTargetEmail($checklist->getTargetEmail() ?? '');
         $newChecklist->setReplyEmail($checklist->getReplyEmail());
         $newChecklist->setEmailTemplate($checklist->getEmailTemplate());
 
         foreach ($checklist->getGroups() as $group) {
             $newGroup = new ChecklistGroup();
-            $newGroup->setTitle($group->getTitle());
+            $newGroup->setTitle($group->getTitle() ?? '');
             $newGroup->setDescription($group->getDescription());
             $newGroup->setSortOrder($group->getSortOrder());
             $newGroup->setChecklist($newChecklist);
 
             foreach ($group->getItems() as $item) {
                 $newItem = new GroupItem();
-                $newItem->setLabel($item->getLabel());
-                $newItem->setType($item->getType());
+                $newItem->setLabel($item->getLabel() ?? '');
+                $newItem->setType($item->getType() ?? '');
                 $newItem->setOptions($item->getOptions());
                 $newItem->setSortOrder($item->getSortOrder());
                 $newGroup->addItem($newItem);

--- a/src/Service/EmailService.php
+++ b/src/Service/EmailService.php
@@ -61,7 +61,7 @@ class EmailService
      */
     public function generateAndSendEmail(Submission $submission): string
     {
-        $template = $submission->getChecklist()->getEmailTemplate() ?? $this->getDefaultTemplate();
+        $template = $submission->getChecklist()?->getEmailTemplate() ?? $this->getDefaultTemplate();
         
         // Platzhalter ersetzen
         $emailContent = $this->replacePlaceholders($template, $submission);
@@ -72,8 +72,8 @@ class EmailService
         // E-Mail an Zieladresse (interne Bearbeitung)
         $targetEmail = (new Email())
             ->from($from)
-            ->to($submission->getChecklist()->getTargetEmail())
-            ->subject('Neue Stückliste eingegangen: ' . $submission->getChecklist()->getTitle() . ' - ' . $submission->getName())
+            ->to($submission->getChecklist()?->getTargetEmail() ?? '')
+            ->subject('Neue Stückliste eingegangen: ' . ($submission->getChecklist()?->getTitle() ?? '') . ' - ' . $submission->getName())
             ->html($emailContent);
             
         $this->getMailer()->send($targetEmail);
@@ -116,9 +116,9 @@ class EmailService
         $placeholders = [
             '{{name}}' => $submission->getName(),
             '{{mitarbeiter_id}}' => $submission->getMitarbeiterId(),
-            '{{stückliste}}' => $submission->getChecklist()->getTitle(),
+            '{{stückliste}}' => $submission->getChecklist()?->getTitle() ?? '',
             '{{auswahl}}' => $auswahl,
-            '{{rueckfragen_email}}' => $submission->getChecklist()->getReplyEmail() ?? ''
+            '{{rueckfragen_email}}' => $submission->getChecklist()?->getReplyEmail() ?? ''
         ];
         
         return str_replace(array_keys($placeholders), array_values($placeholders), $template);

--- a/src/Service/SubmissionService.php
+++ b/src/Service/SubmissionService.php
@@ -14,7 +14,7 @@ class SubmissionService
      * @param Checklist $checklist Die aktuelle Stückliste
      * @param Request   $request   Der HTTP-Request mit den Formdaten
      *
-     * @return array Die strukturierten Bestelldaten
+     * @return array<string, array<string, mixed>> Die strukturierten Bestelldaten
      */
     public function collectSubmissionData(Checklist $checklist, Request $request): array
     {
@@ -27,7 +27,7 @@ class SubmissionService
                 $fieldName = 'item_' . $item->getId();
 
                 $value = match ($item->getType()) {
-                    GroupItem::TYPE_CHECKBOX => $request->request->all($fieldName) ?? [],
+                    GroupItem::TYPE_CHECKBOX => $request->request->all($fieldName),
                     default => $request->request->get($fieldName),
                 };
 
@@ -50,7 +50,7 @@ class SubmissionService
     /**
      * Formatiert übermittelte Daten für den Versand per E-Mail.
      *
-     * @param array $data Die zuvor gesammelten Bestelldaten
+     * @param array<string, array<string, mixed>> $data Die zuvor gesammelten Bestelldaten
      *
      * @return string HTML-Markup für die E-Mail
      */


### PR DESCRIPTION
## Summary
- clean up request handling in controllers
- document array return types
- add generics and stricter types in repositories and entities
- use nullsafe accessors and defaults for email service
- tweak duplication service to handle null values

## Testing
- `composer install --no-interaction`
- `vendor/bin/phpstan analyse --no-progress --memory-limit=512M` *(fails: Found 36 errors)*

------
https://chatgpt.com/codex/tasks/task_e_688525462b6483318310db509fca3d08