### PR TITLE
Refactor linkEmailTemplate handling

### DIFF
--- a/src/Controller/Admin/SubmissionController.php
+++ b/src/Controller/Admin/SubmissionController.php
@@ -94,7 +94,7 @@ class SubmissionController extends AbstractController
     {
         $checklist = $submission->getChecklist();
         if (!$checklist) {
-            throw $this->createNotFoundException('Zugehörige Checkliste nicht gefunden.');
+            throw $this->createNotFoundException(sprintf('Zugehörige Checkliste für Submission #%d nicht gefunden.', $submission->getId()));
         }
         $checklistId = $checklist->getId();
         $token = $request->request->get('_token');

--- a/src/Controller/Admin/SubmissionController.php
+++ b/src/Controller/Admin/SubmissionController.php
@@ -93,6 +93,9 @@ class SubmissionController extends AbstractController
     public function delete(Request $request, Submission $submission): Response
     {
         $checklist = $submission->getChecklist();
+        if (!$checklist) {
+            throw $this->createNotFoundException('Zugehörige Checkliste nicht gefunden.');
+        }
         $checklistId = $checklist->getId();
         $token = $request->request->get('_token');
         $token = is_string($token) ? $token : null;


### PR DESCRIPTION
## Summary
- refactor `linkEmailTemplate` in `ChecklistController` to use common helper
- guard against missing checklist in `SubmissionController`

## Testing
- `vendor/bin/phpstan analyse --memory-limit=512M`
- `vendor/bin/phpmd src text phpmd.xml`

------
https://chatgpt.com/codex/tasks/task_e_688550f05f648331b95b2a753758bdd0