### PR TITLE
Refactor admin checklist controller

### DIFF
--- a/config/routes.yaml
+++ b/config/routes.yaml
@@ -132,13 +132,13 @@ admin_checklist_email_template:
 
 admin_checklist_email_template_download:
     path: /admin/checklists/{id}/email-template/download
-    controller: App\Controller\Admin\ChecklistController::downloadEmailTemplate
+    controller: App\Controller\Admin\ChecklistTemplateController::downloadEmailTemplate
     requirements:
         id: '\d+'
 
 admin_checklist_email_template_reset:
     path: /admin/checklists/{id}/email-template/reset
-    controller: App\Controller\Admin\ChecklistController::resetEmailTemplate
+    controller: App\Controller\Admin\ChecklistTemplateController::resetEmailTemplate
     methods: [POST]
     requirements:
         id: '\d+'

--- a/src/Controller/Admin/ChecklistController.php
+++ b/src/Controller/Admin/ChecklistController.php
@@ -193,51 +193,6 @@ class ChecklistController extends AbstractController
         return $this->redirectToRoute('admin_checklist_email_template', ['id' => $checklist->getId()]);
     }
 
-    /**
-     * Lädt das aktuelle E-Mail-Template als Datei herunter.
-     *
-     * @param Checklist $checklist Die betreffende Checkliste
-     *
-     * @return Response Download der Template-Datei
-     */
-    public function downloadEmailTemplate(Checklist $checklist): Response
-    {
-        $template = $checklist->getEmailTemplate() ?? $this->emailService->getDefaultTemplate();
-        
-        $response = new Response($template);
-        $response->headers->set('Content-Type', 'text/html');
-        $response->headers->set('Content-Disposition', 
-            $response->headers->makeDisposition(
-                ResponseHeaderBag::DISPOSITION_ATTACHMENT,
-                'email-template-' . $checklist->getId() . '.html'
-            )
-        );
-        
-        return $response;
-    }
-
-    /**
-     * Setzt das E-Mail-Template auf den Standard zurück.
-     *
-     * @param Request   $request   Aktuelle HTTP-Anfrage
-     * @param Checklist $checklist Die betreffende Checkliste
-     *
-     * @return Response Weiterleitung nach dem Zurücksetzen
-     */
-    public function resetEmailTemplate(Request $request, Checklist $checklist): Response
-    {
-        $tokenParam = $request->request->get('_token');
-        $token = is_string($tokenParam) ? $tokenParam : null;
-
-        if ($this->isCsrfTokenValid('reset_template' . $checklist->getId(), $token)) {
-            $checklist->setEmailTemplate(null); // Dies wird das Standard-Template verwenden
-            $this->entityManager->flush();
-
-            $this->addFlash('success', 'E-Mail-Template wurde auf Standard zurückgesetzt.');
-        }
-
-        return $this->redirectToRoute('admin_checklist_email_template', ['id' => $checklist->getId()]);
-    }
 
     /**
      * Dupliziert eine vorhandene Checkliste inklusive Gruppen und Items.

--- a/src/Controller/Admin/ChecklistTemplateController.php
+++ b/src/Controller/Admin/ChecklistTemplateController.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Controller\Admin;
+
+use App\Entity\Checklist;
+use App\Service\EmailService;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\ResponseHeaderBag;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[IsGranted('ROLE_ADMIN')]
+class ChecklistTemplateController extends AbstractController
+{
+    public function __construct(
+        private EntityManagerInterface $entityManager,
+        private EmailService $emailService
+    ) {
+    }
+
+    public function downloadEmailTemplate(Checklist $checklist): Response
+    {
+        $template = $checklist->getEmailTemplate() ?? $this->emailService->getDefaultTemplate();
+
+        $response = new Response($template);
+        $response->headers->set('Content-Type', 'text/html');
+        $response->headers->set('Content-Disposition',
+            $response->headers->makeDisposition(
+                ResponseHeaderBag::DISPOSITION_ATTACHMENT,
+                'email-template-' . $checklist->getId() . '.html'
+            )
+        );
+
+        return $response;
+    }
+
+    public function resetEmailTemplate(Request $request, Checklist $checklist): Response
+    {
+        $tokenParam = $request->request->get('_token');
+        $token = is_string($tokenParam) ? $tokenParam : null;
+
+        if ($this->isCsrfTokenValid('reset_template' . $checklist->getId(), $token)) {
+            $checklist->setEmailTemplate(null);
+            $this->entityManager->flush();
+
+            $this->addFlash('success', 'E-Mail-Template wurde auf Standard zurückgesetzt.');
+        }
+
+        return $this->redirectToRoute('admin_checklist_email_template', ['id' => $checklist->getId()]);
+    }
+}


### PR DESCRIPTION
## Summary
- extract template reset and download actions to new `ChecklistTemplateController`
- update routes to use the new controller
- cleanup `ChecklistController` to keep public methods below ten

## Testing
- `vendor/bin/phpstan analyse --no-progress`

------
https://chatgpt.com/codex/tasks/task_e_688554ac47348331801a2b5d83392c93