### PR TITLE
Add PHPUnit tests for command classes

### DIFF
--- a/tests/Command/ChangePasswordCommandTest.php
+++ b/tests/Command/ChangePasswordCommandTest.php
@@ -1,0 +1,85 @@
+<?php
+namespace App\Tests\Command;
+
+use App\Command\ChangePasswordCommand;
+use App\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\Persistence\ObjectRepository;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+
+class ChangePasswordCommandTest extends TestCase
+{
+    public function testExecuteChangesPassword(): void
+    {
+        $user = new User();
+
+        $repository = $this->createMock(ObjectRepository::class);
+        $repository->method('findOneBy')->willReturn($user);
+
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->method('getRepository')->willReturn($repository);
+        $em->expects($this->once())->method('flush');
+
+        $hasher = $this->createMock(UserPasswordHasherInterface::class);
+        $hasher->method('hashPassword')->with($user, $this->anything())->willReturn('hashed');
+
+        $command = new ChangePasswordCommand($em, $hasher);
+        $tester = new CommandTester($command);
+
+        $status = $tester->execute([
+            'email' => 'user@example.com',
+            'password' => str_repeat('x', 16),
+        ]);
+
+        $this->assertSame(Command::SUCCESS, $status);
+        $this->assertStringContainsString('erfolgreich geändert', $tester->getDisplay());
+    }
+
+    public function testExecuteFailsWhenUserNotFound(): void
+    {
+        $repository = $this->createMock(ObjectRepository::class);
+        $repository->method('findOneBy')->willReturn(null);
+
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->method('getRepository')->willReturn($repository);
+        $em->expects($this->never())->method('flush');
+
+        $hasher = $this->createMock(UserPasswordHasherInterface::class);
+
+        $command = new ChangePasswordCommand($em, $hasher);
+        $tester = new CommandTester($command);
+
+        $status = $tester->execute([
+            'email' => 'missing@example.com',
+            'password' => str_repeat('y', 16),
+        ]);
+
+        $this->assertSame(Command::FAILURE, $status);
+        $this->assertStringContainsString('nicht gefunden', $tester->getDisplay());
+    }
+
+    public function testExecuteFailsForShortPassword(): void
+    {
+        $repository = $this->createMock(ObjectRepository::class);
+        $repository->method('findOneBy')->willReturn(new User());
+
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->method('getRepository')->willReturn($repository);
+
+        $hasher = $this->createMock(UserPasswordHasherInterface::class);
+
+        $command = new ChangePasswordCommand($em, $hasher);
+        $tester = new CommandTester($command);
+
+        $status = $tester->execute([
+            'email' => 'user@example.com',
+            'password' => 'short',
+        ]);
+
+        $this->assertSame(Command::FAILURE, $status);
+        $this->assertStringContainsString('mindestens 16 Zeichen', $tester->getDisplay());
+    }
+}

--- a/tests/Command/CreateUserCommandTest.php
+++ b/tests/Command/CreateUserCommandTest.php
@@ -1,0 +1,83 @@
+<?php
+namespace App\Tests\Command;
+
+use App\Command\CreateUserCommand;
+use App\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\Persistence\ObjectRepository;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+
+class CreateUserCommandTest extends TestCase
+{
+    public function testExecuteCreatesUser(): void
+    {
+        $repository = $this->createMock(ObjectRepository::class);
+        $repository->method('findOneBy')->willReturn(null);
+
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->method('getRepository')->willReturn($repository);
+        $em->expects($this->once())->method('persist')->with($this->isInstanceOf(User::class));
+        $em->expects($this->once())->method('flush');
+
+        $hasher = $this->createMock(UserPasswordHasherInterface::class);
+        $hasher->method('hashPassword')->willReturn('hashed');
+
+        $command = new CreateUserCommand($em, $hasher);
+        $tester = new CommandTester($command);
+
+        $status = $tester->execute([
+            'email' => 'new@example.com',
+            'password' => str_repeat('a', 16),
+        ]);
+
+        $this->assertSame(Command::SUCCESS, $status);
+        $this->assertStringContainsString('erfolgreich erstellt', $tester->getDisplay());
+    }
+
+    public function testExecuteFailsIfUserExists(): void
+    {
+        $repository = $this->createMock(ObjectRepository::class);
+        $repository->method('findOneBy')->willReturn(new User());
+
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->method('getRepository')->willReturn($repository);
+        $em->expects($this->never())->method('persist');
+
+        $hasher = $this->createMock(UserPasswordHasherInterface::class);
+
+        $command = new CreateUserCommand($em, $hasher);
+        $tester = new CommandTester($command);
+
+        $status = $tester->execute([
+            'email' => 'existing@example.com',
+            'password' => str_repeat('b', 16),
+        ]);
+
+        $this->assertSame(Command::FAILURE, $status);
+        $this->assertStringContainsString('existiert bereits', $tester->getDisplay());
+    }
+
+    public function testExecuteFailsForShortPassword(): void
+    {
+        $repository = $this->createMock(ObjectRepository::class);
+        $repository->method('findOneBy')->willReturn(null);
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->method('getRepository')->willReturn($repository);
+
+        $hasher = $this->createMock(UserPasswordHasherInterface::class);
+
+        $command = new CreateUserCommand($em, $hasher);
+        $tester = new CommandTester($command);
+
+        $status = $tester->execute([
+            'email' => 'short@example.com',
+            'password' => 'short',
+        ]);
+
+        $this->assertSame(Command::FAILURE, $status);
+        $this->assertStringContainsString('mindestens 16 Zeichen', $tester->getDisplay());
+    }
+}

--- a/tests/Command/CreateUserCommandTest.php
+++ b/tests/Command/CreateUserCommandTest.php
@@ -12,6 +12,7 @@ use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
 
 class CreateUserCommandTest extends TestCase
 {
+    private const MIN_PASSWORD_LENGTH = 16;
     public function testExecuteCreatesUser(): void
     {
         $repository = $this->createMock(ObjectRepository::class);
@@ -30,7 +31,7 @@ class CreateUserCommandTest extends TestCase
 
         $status = $tester->execute([
             'email' => 'new@example.com',
-            'password' => str_repeat('a', 16),
+            'password' => str_repeat('a', self::MIN_PASSWORD_LENGTH),
         ]);
 
         $this->assertSame(Command::SUCCESS, $status);
@@ -53,7 +54,7 @@ class CreateUserCommandTest extends TestCase
 
         $status = $tester->execute([
             'email' => 'existing@example.com',
-            'password' => str_repeat('b', 16),
+            'password' => str_repeat('b', self::MIN_PASSWORD_LENGTH),
         ]);
 
         $this->assertSame(Command::FAILURE, $status);


### PR DESCRIPTION
## Summary
- add `CreateUserCommandTest` verifying user creation and failures
- add `ChangePasswordCommandTest` verifying password change and errors

## Testing
- `vendor/bin/phpunit --testdox`

------
https://chatgpt.com/codex/tasks/task_e_6885bfd0f7408331af316db3539b9cfa