### PR TITLE
Add tests for GroupItem entity

### DIFF
--- a/tests/Entity/GroupItemTest.php
+++ b/tests/Entity/GroupItemTest.php
@@ -1,0 +1,55 @@
+<?php
+namespace App\Tests\Entity;
+
+use App\Entity\GroupItem;
+use PHPUnit\Framework\TestCase;
+
+class GroupItemTest extends TestCase
+{
+    public function testGetOptionsArrayEmptyByDefault(): void
+    {
+        $item = new GroupItem();
+        $this->assertSame([], $item->getOptionsArray());
+    }
+
+    public function testSetAndGetOptionsArray(): void
+    {
+        $item = new GroupItem();
+        $item->setOptionsArray(['A', 'B']);
+        $this->assertSame(['A', 'B'], $item->getOptionsArray());
+        $this->assertSame([
+            ['label' => 'A', 'active' => false],
+            ['label' => 'B', 'active' => false],
+        ], $item->getOptionsWithActive());
+    }
+
+    public function testSetOptionsArrayWithActiveTrue(): void
+    {
+        $item = new GroupItem();
+        $item->setOptionsArray(['A', 'B'], true);
+        $this->assertSame([
+            ['label' => 'A', 'active' => true],
+            ['label' => 'B', 'active' => true],
+        ], $item->getOptionsWithActive());
+    }
+
+    public function testGetOptionsLines(): void
+    {
+        $item = new GroupItem();
+        $item->setOptionsWithActive([
+            ['label' => 'Foo', 'active' => true],
+            ['label' => 'Bar', 'active' => false],
+        ]);
+        $this->assertSame(['Foo (aktiv)', 'Bar'], $item->getOptionsLines());
+    }
+
+    public function testGetOptionsWithActiveHandlesInvalidJson(): void
+    {
+        $item = new GroupItem();
+        $item->setOptions('{invalid');
+        $this->assertSame([], $item->getOptionsWithActive());
+
+        $item->setOptions('"foo"');
+        $this->assertSame([], $item->getOptionsWithActive());
+    }
+}


### PR DESCRIPTION
## Summary
- add missing PHPUnit tests for the `GroupItem` entity

## Testing
- `vendor/bin/phpunit --configuration phpunit.xml.dist`

------
https://chatgpt.com/codex/tasks/task_e_6885c028be6083319798f84ba6dedcda