### PR TITLE
Rename checklist_id query parameter

### DIFF
--- a/README-DEPLOYMENT.md
+++ b/README-DEPLOYMENT.md
@@ -127,7 +127,7 @@ besteller/
 
 ### Link-Format für Führungskräfte
 ```
-http://localhost:8081/checklist/{stückliste_id}?name=Max%20Mustermann&mitarbeiter_id=12345&email=max@example.com
+http://localhost:8081/checklist/{checklist_id}?name=Max%20Mustermann&mitarbeiter_id=12345&email=max@example.com
 ```
 
 ### E-Mail-Template Platzhalter

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Ziel dieser Anwendung ist die digitale Erfassung von benötigter Ausstattung fü
 
 **Akzeptanzkriterien:**
 - Der Link enthält:
-  - `stückliste_id`
+  - `checklist_id`
   - `name`
   - `mitarbeiter_id`
   - `email` (E-Mail der Führungskraft)

--- a/src/Controller/Admin/ChecklistController.php
+++ b/src/Controller/Admin/ChecklistController.php
@@ -231,7 +231,7 @@ class ChecklistController extends AbstractController
                 $this->addFlash('error', 'Bitte Empfängerdaten und Personen-ID vollständig angeben.');
             } else {
                 $link = $this->urlGenerator->generate('checklist_form', [
-                    'stückliste_id' => $checklist->getId(),
+                    'checklist_id' => $checklist->getId(),
                     'name' => $personName ?? $recipientName,
                     'mitarbeiter_id' => $mitarbeiterId,
                     'email' => $recipientEmail,

--- a/src/Controller/ChecklistController.php
+++ b/src/Controller/ChecklistController.php
@@ -168,13 +168,13 @@ class ChecklistController extends AbstractController
      */
     public function form(Request $request): Response
     {
-        $stücklisteId = $request->query->get('stückliste_id');
-        if (!$stücklisteId) {
+        $checklistIdParam = $request->query->get('checklist_id');
+        if (!$checklistIdParam) {
             throw new NotFoundHttpException('Ungültige Parameter');
         }
 
         [$name, $mitarbeiterId, $email] = $this->getRequestValuesFromQuery($request);
-        $checklist = $this->getChecklistOr404((int) $stücklisteId);
+        $checklist = $this->getChecklistOr404((int) $checklistIdParam);
 
         $existingSubmission = $this->findExistingSubmission($checklist, $mitarbeiterId);
 

--- a/templates/admin/checklist/edit.html.twig
+++ b/templates/admin/checklist/edit.html.twig
@@ -282,7 +282,7 @@
                 <div class="input-group">
                     <input type="text" class="form-control form-control-sm" 
                            value="{{ url('checklist_form', {
-                               'stückliste_id': checklist.id,
+                               'checklist_id': checklist.id,
                                'name': 'Max Mustermann',
                                'mitarbeiter_id': '12345',
                                'email': 'max.mustermann@example.com'


### PR DESCRIPTION
## Summary
- rename `$stücklisteId` variable to `$checklistIdParam`
- update query parameter key to `checklist_id`
- adjust admin link generator and template
- document new parameter name in README files

## Testing
- `composer install`
- `vendor/bin/phpunit -c phpunit.xml.dist`

------
https://chatgpt.com/codex/tasks/task_e_6885c41b3a748331ac819b1849079141