### PR TITLE
Refactor submission creation

### DIFF
--- a/src/Service/SubmissionFactory.php
+++ b/src/Service/SubmissionFactory.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Service;
+
+use App\Entity\Checklist;
+use App\Entity\Submission;
+use DateTimeImmutable;
+use Doctrine\ORM\EntityManagerInterface;
+
+class SubmissionFactory
+{
+    public function __construct(private EntityManagerInterface $entityManager)
+    {
+    }
+
+    /**
+     * @param array<string, array<string, mixed>> $data
+     */
+    public function createSubmission(
+        Checklist $checklist,
+        string $name,
+        string $mitarbeiterId,
+        string $email,
+        array $data,
+        bool $persist = false
+    ): Submission {
+        $submission = new Submission();
+        $submission->setChecklist($checklist);
+        $submission->setName($name);
+        $submission->setMitarbeiterId($mitarbeiterId);
+        $submission->setEmail($email);
+        $submission->setData($data);
+        $submission->setSubmittedAt(new DateTimeImmutable());
+
+        if ($persist) {
+            $this->entityManager->persist($submission);
+            $this->entityManager->flush();
+        }
+
+        return $submission;
+    }
+}

--- a/tests/Service/SubmissionFactoryTest.php
+++ b/tests/Service/SubmissionFactoryTest.php
@@ -1,0 +1,42 @@
+<?php
+namespace App\Tests\Service;
+
+use App\Entity\Checklist;
+use App\Entity\Submission;
+use App\Service\SubmissionFactory;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\TestCase;
+
+class SubmissionFactoryTest extends TestCase
+{
+    public function testCreateSubmissionWithoutPersist(): void
+    {
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->expects($this->never())->method('persist');
+        $em->expects($this->never())->method('flush');
+
+        $factory = new SubmissionFactory($em);
+        $checklist = new Checklist();
+
+        $submission = $factory->createSubmission($checklist, 'Alice', '1', 'a@test', ['foo' => []]);
+
+        $this->assertInstanceOf(Submission::class, $submission);
+        $this->assertSame($checklist, $submission->getChecklist());
+        $this->assertSame('Alice', $submission->getName());
+        $this->assertSame('1', $submission->getMitarbeiterId());
+        $this->assertSame('a@test', $submission->getEmail());
+        $this->assertSame(['foo' => []], $submission->getData());
+    }
+
+    public function testCreateSubmissionWithPersist(): void
+    {
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->expects($this->once())->method('persist')->with($this->isInstanceOf(Submission::class));
+        $em->expects($this->once())->method('flush');
+
+        $factory = new SubmissionFactory($em);
+        $checklist = new Checklist();
+
+        $factory->createSubmission($checklist, 'Bob', '2', 'b@test', [], true);
+    }
+}


### PR DESCRIPTION
## Summary
- add SubmissionFactory service to centralize Submission entity creation
- use the factory inside ChecklistController
- test the new factory service

## Testing
- `./vendor/bin/phpunit --colors=never`
- `./vendor/bin/phpstan analyse --memory-limit=512M`
- `./vendor/bin/phpmd src text phpmd.xml`

------
https://chatgpt.com/codex/tasks/task_e_6885c42bacc8833191f66edc6a9f9359