### PR TITLE
Implement /api/generate-link endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,3 +195,26 @@ Die folgenden Platzhalter stehen im HTML-Template zur Verfügung:
 - **Frontend:** Bootstrap für UI-Komponenten
 - **Backend:** Symfony Commands zur Userverwaltung
 - **Keine API-Anbindung oder externes SSO erforderlich**
+
+## Beispiel: Link über die API generieren
+
+Mit einem POST-Request an `/api/generate-link` kann ein gültiger Link zu einer vorhandenen Stückliste erstellt werden. Beispielaufruf:
+
+```bash
+curl -X POST https://besteller.example.com/api/generate-link \
+     -H 'Content-Type: application/json' \
+     -d '{
+           "stückliste_id": 123,
+           "mitarbeiter_name": "Max Muster",
+           "mitarbeiter_id": "abc-123",
+           "email_empfänger": "chef@example.com"
+         }'
+```
+
+Die Antwort enthält den öffentlichen Link zur Auswahlseite:
+
+```json
+{
+  "link": "https://besteller.example.com/auswahl?list=123&name=Max%20Muster&id=abc-123&email=chef@example.com"
+}
+```

--- a/config/routes.yaml
+++ b/config/routes.yaml
@@ -29,6 +29,15 @@ checklist_form:
     path: /form
     controller: App\Controller\ChecklistController::form
 
+checklist_selection:
+    path: /auswahl
+    controller: App\Controller\ChecklistController::form
+
+api_generate_link:
+    path: /api/generate-link
+    controller: App\Controller\ApiController::generateLink
+    methods: [POST]
+
 # Admin routes
 admin_dashboard:
     path: /admin

--- a/src/Controller/ApiController.php
+++ b/src/Controller/ApiController.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Controller;
+
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+
+class ApiController extends AbstractController
+{
+    public function __construct(private UrlGeneratorInterface $urlGenerator)
+    {
+    }
+
+    public function generateLink(Request $request): JsonResponse
+    {
+        $configuredTokenRaw = $_ENV['API_TOKEN'] ?? null;
+        $configuredToken = is_string($configuredTokenRaw) ? $configuredTokenRaw : '';
+        if ($configuredToken !== '') {
+            $auth = $request->headers->get('Authorization', '');
+            if ($auth !== 'Bearer ' . $configuredToken) {
+                return new JsonResponse(['error' => 'Unauthorized'], Response::HTTP_UNAUTHORIZED);
+            }
+        }
+
+        $data = json_decode($request->getContent(), true);
+        if (!is_array($data)) {
+            return new JsonResponse(['error' => 'Ungültiges JSON'], Response::HTTP_BAD_REQUEST);
+        }
+
+        $required = ['stückliste_id', 'mitarbeiter_name', 'mitarbeiter_id', 'email_empfänger'];
+        foreach ($required as $field) {
+            if (empty($data[$field])) {
+                return new JsonResponse(['error' => 'Fehlende Parameter'], Response::HTTP_BAD_REQUEST);
+            }
+        }
+
+        $link = $this->urlGenerator->generate('checklist_selection', [
+            'list' => $data['stückliste_id'],
+            'name' => $data['mitarbeiter_name'],
+            'id' => $data['mitarbeiter_id'],
+            'email' => $data['email_empfänger'],
+        ], UrlGeneratorInterface::ABSOLUTE_URL);
+
+        return new JsonResponse(['link' => $link]);
+    }
+}

--- a/src/Controller/ChecklistController.php
+++ b/src/Controller/ChecklistController.php
@@ -46,7 +46,7 @@ class ChecklistController extends AbstractController
     private function extractRequestValues(ParameterBag $source): array
     {
         $name = $source->getString('name', '');
-        $mitarbeiterId = $source->getString('mitarbeiter_id', '');
+        $mitarbeiterId = $source->getString('mitarbeiter_id', $source->getString('id', ''));
         $email = $source->getString('email', '');
 
         if ($name === '' || $mitarbeiterId === '' || $email === '') {
@@ -172,6 +172,9 @@ class ChecklistController extends AbstractController
     public function form(Request $request): Response
     {
         $checklistIdParam = $request->query->get('checklist_id');
+        if (!$checklistIdParam) {
+            $checklistIdParam = $request->query->get('list');
+        }
         if (!$checklistIdParam) {
             throw new NotFoundHttpException('Ungültige Parameter');
         }

--- a/tests/Controller/ApiControllerTest.php
+++ b/tests/Controller/ApiControllerTest.php
@@ -1,0 +1,74 @@
+<?php
+namespace App\Tests\Controller;
+
+use App\Controller\ApiController;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+
+class ApiControllerTest extends TestCase
+{
+    public function testGenerateLinkReturnsLink(): void
+    {
+        $url = 'https://example.com/auswahl?list=123&name=Max%20Muster&id=abc-123&email=chef@example.com';
+        $urlGenerator = $this->createMock(UrlGeneratorInterface::class);
+        $urlGenerator->expects($this->once())
+            ->method('generate')
+            ->with(
+                'checklist_selection',
+                [
+                    'list' => 123,
+                    'name' => 'Max Muster',
+                    'id' => 'abc-123',
+                    'email' => 'chef@example.com',
+                ],
+                UrlGeneratorInterface::ABSOLUTE_URL
+            )
+            ->willReturn($url);
+
+        $request = new Request([], [], [], [], [], [], json_encode([
+            'stückliste_id' => 123,
+            'mitarbeiter_name' => 'Max Muster',
+            'mitarbeiter_id' => 'abc-123',
+            'email_empfänger' => 'chef@example.com',
+        ]));
+
+        $controller = new ApiController($urlGenerator);
+        $response = $controller->generateLink($request);
+
+        $this->assertInstanceOf(JsonResponse::class, $response);
+        $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
+        $data = json_decode($response->getContent(), true);
+        $this->assertSame($url, $data['link']);
+    }
+
+    public function testGenerateLinkRequiresParameters(): void
+    {
+        $urlGenerator = $this->createMock(UrlGeneratorInterface::class);
+        $controller = new ApiController($urlGenerator);
+        $request = new Request([], [], [], [], [], [], json_encode(['foo' => 'bar']));
+
+        $response = $controller->generateLink($request);
+        $this->assertSame(Response::HTTP_BAD_REQUEST, $response->getStatusCode());
+    }
+
+    public function testGenerateLinkChecksBearerToken(): void
+    {
+        $_ENV['API_TOKEN'] = 'secret';
+        $urlGenerator = $this->createMock(UrlGeneratorInterface::class);
+        $controller = new ApiController($urlGenerator);
+        $request = new Request([], [], [], [], [], [], json_encode([
+            'stückliste_id' => 1,
+            'mitarbeiter_name' => 'A',
+            'mitarbeiter_id' => 'B',
+            'email_empfänger' => 'a@example.com',
+        ]));
+        $request->headers->set('Authorization', 'Bearer wrong');
+
+        $response = $controller->generateLink($request);
+        $this->assertSame(Response::HTTP_UNAUTHORIZED, $response->getStatusCode());
+        unset($_ENV['API_TOKEN']);
+    }
+}


### PR DESCRIPTION
## Summary
- generate public checklist links via a new API endpoint
- accept alternative query parameters for `/auswahl`
- add `/auswahl` route
- allow bearer token authentication via `API_TOKEN`
- **add missing unit tests for the API and show a curl example**

## Testing
- `composer exec phpunit`
- `./vendor/bin/phpstan analyse --no-progress --memory-limit=512M`
- `./vendor/bin/phpmd src text phpmd.xml`

------
https://chatgpt.com/codex/tasks/task_e_6885d646ec4c8331906e9d114c7e3b49