### PR TITLE
Refactor GroupItem options methods

### DIFF
--- a/src/Entity/GroupItem.php
+++ b/src/Entity/GroupItem.php
@@ -14,9 +14,9 @@ class GroupItem
 
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(type: 'integer')]
+    #[ORM\Column(name: 'id', type: 'integer')]
     /** @phpstan-ignore-next-line */
-    private ?int $id = null;
+    private ?int $identifier = null;
 
     #[ORM\Column(type: 'string', length: 255)]
     private ?string $label = null;
@@ -36,7 +36,7 @@ class GroupItem
 
     public function getId(): ?int
     {
-        return $this->id;
+        return $this->identifier;
     }
 
     public function getLabel(): ?string
@@ -130,10 +130,25 @@ class GroupItem
      *
      * @param list<string> $options
      */
-    public function setOptionsArray(array $options, bool $active = false): static
+    public function setOptionsArray(array $options): static
     {
         $structured = array_map(
-            fn(string $label) => ['label' => $label, 'active' => $active],
+            fn(string $label) => ['label' => $label, 'active' => false],
+            $options
+        );
+        $this->options = json_encode($structured, JSON_THROW_ON_ERROR);
+        return $this;
+    }
+
+    /**
+     * Speichert eine Liste von Optionen und setzt sie aktiv
+     *
+     * @param list<string> $options
+     */
+    public function setActiveOptionsArray(array $options): static
+    {
+        $structured = array_map(
+            fn(string $label) => ['label' => $label, 'active' => true],
             $options
         );
         $this->options = json_encode($structured, JSON_THROW_ON_ERROR);
@@ -152,7 +167,7 @@ class GroupItem
             return [];
         }
 
-        return array_values(array_map([self::class, 'normalizeOption'], $decoded));
+        return array_values(array_map(fn($opt) => self::normalizeOption($opt), $decoded));
     }
 
     /**

--- a/tests/Entity/GroupItemTest.php
+++ b/tests/Entity/GroupItemTest.php
@@ -23,10 +23,10 @@ class GroupItemTest extends TestCase
         ], $item->getOptionsWithActive());
     }
 
-    public function testSetOptionsArrayWithActiveTrue(): void
+    public function testSetActiveOptionsArray(): void
     {
         $item = new GroupItem();
-        $item->setOptionsArray(['A', 'B'], true);
+        $item->setActiveOptionsArray(['A', 'B']);
         $this->assertSame([
             ['label' => 'A', 'active' => true],
             ['label' => 'B', 'active' => true],

--- a/tests/Service/SubmissionServiceTest.php
+++ b/tests/Service/SubmissionServiceTest.php
@@ -15,7 +15,7 @@ class SubmissionServiceTest extends TestCase
         $item = new GroupItem();
         $item->setLabel($label);
         $item->setType($type);
-        $ref = new \ReflectionProperty(GroupItem::class, 'id');
+        $ref = new \ReflectionProperty(GroupItem::class, 'identifier');
         $ref->setAccessible(True);
         $ref->setValue($item, $id);
         return $item;


### PR DESCRIPTION
## Summary
- rename `GroupItem::$id` property to `identifier`
- replace boolean flag in `setOptionsArray` with new `setActiveOptionsArray`
- call `normalizeOption` directly when reading options
- adjust unit tests for new methods

## Testing
- `./vendor/bin/phpunit -c phpunit.xml.dist`
- `./vendor/bin/phpstan analyse -c phpstan.neon --memory-limit=256M`
- `./vendor/bin/phpmd src text phpmd.xml`

------
https://chatgpt.com/codex/tasks/task_e_6885e0ea2d9c8331bdf0b0261dd65da5