### PR TITLE
Display checkbox choices as sublist in emails

### DIFF
--- a/src/Service/SubmissionService.php
+++ b/src/Service/SubmissionService.php
@@ -67,8 +67,13 @@ class SubmissionService
                     $value = $itemData['value'];
 
                     if (is_array($value)) {
-                        // Checkbox-Arrays
-                        $output .= "<li><strong>{$itemLabel}:</strong> " . implode(', ', $value) . "</li>\n";
+                        // Checkbox-Arrays als Unterliste ausgeben
+                        $output .= "<li><strong>{$itemLabel}:</strong><ul>\n";
+                        foreach ($value as $val) {
+                            $val = is_scalar($val) ? nl2br((string) $val) : nl2br('');
+                            $output .= "<li>{$val}</li>\n";
+                        }
+                        $output .= "</ul></li>\n";
                         continue;
                     }
 
@@ -80,7 +85,12 @@ class SubmissionService
 
                 // Fallback für alte Datenstruktur
                 if (is_array($itemData)) {
-                    $output .= "<li><strong>{$itemLabel}:</strong> " . implode(', ', $itemData) . "</li>\n";
+                    $output .= "<li><strong>{$itemLabel}:</strong><ul>\n";
+                    foreach ($itemData as $val) {
+                        $val = is_scalar($val) ? nl2br((string) $val) : nl2br('');
+                        $output .= "<li>{$val}</li>\n";
+                    }
+                    $output .= "</ul></li>\n";
                     continue;
                 }
 

--- a/tests/Service/SubmissionServiceTest.php
+++ b/tests/Service/SubmissionServiceTest.php
@@ -64,6 +64,8 @@ class SubmissionServiceTest extends TestCase
         $html = $service->formatSubmissionForEmail($data);
         $this->assertStringContainsString('<h3>Group</h3>', $html);
         $this->assertStringContainsString('<strong>Text:</strong> Foo', $html);
-        $this->assertStringContainsString('<strong>Options:</strong> A, B', $html);
+        $this->assertStringContainsString('<strong>Options:</strong><ul>', $html);
+        $this->assertStringContainsString('<li>A</li>', $html);
+        $this->assertStringContainsString('<li>B</li>', $html);
     }
 }


### PR DESCRIPTION
## Summary
- render checkbox values as nested lists when composing emails
- update tests for new list format

## Testing
- `composer install`
- `vendor/bin/phpunit --colors=always`

------
https://chatgpt.com/codex/tasks/task_e_6885ee2e40348331bdcd55a82ae5e79b