### PR TITLE
feat: allow editing confirmation email template

### DIFF
--- a/config/routes.yaml
+++ b/config/routes.yaml
@@ -161,6 +161,14 @@ admin_email_settings:
     path: /admin/email-settings
     controller: App\Controller\Admin\EmailSettingsController::edit
 
+admin_confirmation_template:
+    path: /admin/confirmation-template
+    controller: App\Controller\Admin\ConfirmationTemplateController::edit
+
+admin_confirmation_template_download:
+    path: /admin/confirmation-template/download
+    controller: App\Controller\Admin\ConfirmationTemplateController::download
+
 # Benutzerverwaltung
 admin_users:
     path: /admin/users

--- a/migrations/Version20250727000006.php
+++ b/migrations/Version20250727000006.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20250727000006 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add confirmation_email_template column to email_settings';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql("ALTER TABLE email_settings ADD confirmation_email_template LONGTEXT DEFAULT NULL");
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql("ALTER TABLE email_settings DROP confirmation_email_template");
+    }
+}

--- a/src/Controller/Admin/ConfirmationTemplateController.php
+++ b/src/Controller/Admin/ConfirmationTemplateController.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace App\Controller\Admin;
+
+use App\Entity\EmailSettings;
+use App\Service\EmailService;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\ResponseHeaderBag;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[IsGranted('ROLE_ADMIN')]
+class ConfirmationTemplateController extends AbstractController
+{
+    public function __construct(
+        private EntityManagerInterface $entityManager,
+        private EmailService $emailService
+    ) {
+    }
+
+    public function edit(Request $request): Response
+    {
+        $settings = $this->entityManager->getRepository(EmailSettings::class)->find(1);
+        if (!$settings) {
+            $settings = new EmailSettings();
+            $this->entityManager->persist($settings);
+        }
+
+        if (!$request->isMethod('POST')) {
+            return $this->render('admin/confirmation_template.html.twig', [
+                'currentTemplate' => $settings->getConfirmationEmailTemplate() ?? $this->emailService->getConfirmationTemplate(),
+            ]);
+        }
+
+        $result = $this->extractTemplateContent($request, 'admin_confirmation_template');
+        if ($result instanceof Response) {
+            return $result;
+        }
+
+        $settings->setConfirmationEmailTemplate($result);
+        $this->entityManager->flush();
+
+        $this->addFlash('success', 'Best\u00E4tigungs-Template wurde erfolgreich aktualisiert.');
+
+        return $this->redirectToRoute('admin_confirmation_template');
+    }
+
+    public function download(): Response
+    {
+        $settings = $this->entityManager->getRepository(EmailSettings::class)->find(1);
+        $template = $settings?->getConfirmationEmailTemplate() ?? $this->emailService->getConfirmationTemplate();
+
+        $response = new Response($template);
+        $response->headers->set('Content-Type', 'text/html');
+        $response->headers->set('Content-Disposition',
+            $response->headers->makeDisposition(
+                ResponseHeaderBag::DISPOSITION_ATTACHMENT,
+                'confirmation-template.html'
+            )
+        );
+
+        return $response;
+    }
+
+    private function extractTemplateContent(Request $request, string $route): Response|string
+    {
+        $uploadedFile = $request->files->get('template_file');
+        $templateRaw = $request->request->get('template_content');
+        $templateContent = is_string($templateRaw) ? $templateRaw : null;
+
+        if ($uploadedFile) {
+            $mimeType = $uploadedFile->getMimeType();
+            $extension = strtolower($uploadedFile->getClientOriginalExtension());
+
+            if (!in_array($mimeType, ['text/html', 'text/plain']) && !in_array($extension, ['html', 'htm'])) {
+                $this->addFlash('error', 'Bitte laden Sie nur HTML-Dateien hoch (.html oder .htm). Detektierter MIME-Typ: ' . $mimeType . '.');
+                return $this->redirectToRoute($route);
+            }
+
+            if ($uploadedFile->getSize() > 1024 * 1024) {
+                $this->addFlash('error', 'Die Datei ist zu gro\u00DF. Maximale Gr\u00F6\u00DFe: 1MB.');
+                return $this->redirectToRoute($route);
+            }
+
+            $fileContent = file_get_contents($uploadedFile->getPathname());
+            if ($fileContent === false) {
+                $this->addFlash('error', 'Die hochgeladene Datei konnte nicht gelesen werden.');
+                return $this->redirectToRoute($route);
+            }
+
+            $templateContent = $fileContent;
+        }
+
+        if ($templateContent === null || $templateContent === '') {
+            $this->addFlash('error', 'Bitte geben Sie Template-Inhalt ein oder laden eine Datei hoch.');
+            return $this->redirectToRoute($route);
+        }
+
+        return $templateContent;
+    }
+}

--- a/src/Entity/EmailSettings.php
+++ b/src/Entity/EmailSettings.php
@@ -32,6 +32,9 @@ class EmailSettings
     #[ORM\Column(type: 'string', length: 255)]
     private string $senderEmail = 'noreply@besteller.local';
 
+    #[ORM\Column(type: 'text', nullable: true)]
+    private ?string $confirmationEmailTemplate = null;
+
     public function getId(): ?int
     {
         return $this->id;
@@ -100,6 +103,17 @@ class EmailSettings
     public function setSenderEmail(string $senderEmail): static
     {
         $this->senderEmail = $senderEmail;
+        return $this;
+    }
+
+    public function getConfirmationEmailTemplate(): ?string
+    {
+        return $this->confirmationEmailTemplate;
+    }
+
+    public function setConfirmationEmailTemplate(?string $confirmationEmailTemplate): static
+    {
+        $this->confirmationEmailTemplate = $confirmationEmailTemplate;
         return $this;
     }
 }

--- a/src/Service/EmailService.php
+++ b/src/Service/EmailService.php
@@ -79,7 +79,7 @@ class EmailService
         $this->getMailer()->send($targetEmail);
         
         // E-Mail an Führungskraft (Bestätigung)
-        $confirmationTemplate = $this->getConfirmationTemplate();
+        $confirmationTemplate = $settings?->getConfirmationEmailTemplate() ?? $this->getConfirmationTemplate();
         $confirmationContent = $this->replacePlaceholders($confirmationTemplate, $submission);
         
         $managerEmail = (new Email())
@@ -217,7 +217,7 @@ class EmailService
     /**
      * Liefert das Standardtemplate für die Bestätigungs-E-Mail an die Führungskraft.
      */
-    private function getConfirmationTemplate(): string
+    public function getConfirmationTemplate(): string
     {
         return '
 <!DOCTYPE html>

--- a/templates/admin/base.html.twig
+++ b/templates/admin/base.html.twig
@@ -53,6 +53,11 @@
                             </a>
                         </li>
                         <li class="nav-item">
+                            <a class="nav-link {% if app.request.get('_route') starts with 'admin_confirmation_template' %}active{% endif %}" href="{{ path('admin_confirmation_template') }}">
+                                <i class="fas fa-check"></i> Best\u00E4tigungs-Mail Template
+                            </a>
+                        </li>
+                        <li class="nav-item">
                             <a class="nav-link {% if app.request.get('_route') starts with 'admin_user' %}active{% endif %}" href="{{ path('admin_users') }}">
                                 <i class="fas fa-users"></i> Benutzer
                             </a>

--- a/templates/admin/confirmation_template.html.twig
+++ b/templates/admin/confirmation_template.html.twig
@@ -1,0 +1,38 @@
+{% extends 'admin/base.html.twig' %}
+
+{% block title %}Best\u00E4tigungs-Mail-Template{% endblock %}
+
+{% block content %}
+<div class="d-flex justify-content-between align-items-center mb-4">
+    <h1>Best\u00E4tigungs-Mail-Template</h1>
+    <div class="btn-group">
+        <a href="{{ path('admin_confirmation_template_download') }}" class="btn btn-outline-primary">
+            <i class="fas fa-download"></i> Template herunterladen
+        </a>
+        <a href="{{ path('admin_dashboard') }}" class="btn btn-secondary">
+            <i class="fas fa-arrow-left"></i> Zur\u00FCck
+        </a>
+    </div>
+</div>
+
+{% for type, messages in app.flashes %}
+    {% for message in messages %}
+        <div class="alert alert-{{ type == 'error' ? 'danger' : 'success' }} alert-dismissible fade show">
+            {{ message }}
+            <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
+        </div>
+    {% endfor %}
+{% endfor %}
+
+<form method="post" enctype="multipart/form-data">
+    <div class="mb-3">
+        <label class="form-label">HTML-Datei hochladen</label>
+        <input type="file" name="template_file" accept=".html,.htm" class="form-control">
+    </div>
+    <div class="mb-3">
+        <label class="form-label">Template-Inhalt</label>
+        <textarea name="template_content" class="form-control" rows="15">{{ currentTemplate }}</textarea>
+    </div>
+    <button type="submit" class="btn btn-primary">Speichern</button>
+</form>
+{% endblock %}

--- a/templates/admin/confirmation_template.html.twig
+++ b/templates/admin/confirmation_template.html.twig
@@ -25,6 +25,7 @@
 {% endfor %}
 
 <form method="post" enctype="multipart/form-data">
+    <input type="hidden" name="_csrf_token" value="{{ csrf_token }}">
     <div class="mb-3">
         <label class="form-label">HTML-Datei hochladen</label>
         <input type="file" name="template_file" accept=".html,.htm" class="form-control">


### PR DESCRIPTION
## Summary
- allow admins to edit and download the supervisor confirmation email template
- store custom confirmation template in email settings and use when sending
- add navigation entry for confirmation template management

## Testing
- `vendor/bin/phpunit`
- `vendor/bin/phpstan analyse` *(fails: PHPStan process crashed because it reached configured PHP memory limit)*


------
https://chatgpt.com/codex/tasks/task_e_689db444b3488331b5384d680c92afea