### PR TITLE
Prevent sending links with invalid or duplicate person IDs

### DIFF
--- a/tests/Controller/ApiControllerTest.php
+++ b/tests/Controller/ApiControllerTest.php
@@ -136,8 +136,13 @@ class ApiControllerTest extends TestCase
             'intro' => 'Intro',
         ]));
 
+        $submissionRepo = $this->createMock(\App\Repository\SubmissionRepository::class);
+        $submissionRepo->expects($this->once())
+            ->method('findOneBy')
+            ->willReturn(null);
+
         $controller = new ApiController($urlGenerator, $parameterBag);
-        $response = $controller->sendLink($request, $repo, $emailService);
+        $response = $controller->sendLink($request, $repo, $emailService, $submissionRepo);
 
         $this->assertInstanceOf(JsonResponse::class, $response);
         $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
@@ -155,10 +160,11 @@ class ApiControllerTest extends TestCase
 
         $repo = $this->createMock(\App\Repository\ChecklistRepository::class);
         $emailService = $this->createMock(\App\Service\EmailService::class);
+        $submissionRepo = $this->createMock(\App\Repository\SubmissionRepository::class);
 
         $controller = new ApiController($urlGenerator, $parameterBag);
         $request = new Request([], [], [], [], [], [], json_encode(['foo' => 'bar']));
-        $response = $controller->sendLink($request, $repo, $emailService);
+        $response = $controller->sendLink($request, $repo, $emailService, $submissionRepo);
 
         $this->assertSame(Response::HTTP_BAD_REQUEST, $response->getStatusCode());
     }


### PR DESCRIPTION
## Summary
- Validate person ID format and check for existing submissions when sending checklist links via admin UI
- Apply the same validations to API endpoints and return error for duplicates
- Update API controller tests for new repository dependency

## Testing
- `./vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_689db67587848331a5ce3b8276299e71