### PR TITLE
Fix Submission repository method usage

### DIFF
--- a/src/Entity/Submission.php
+++ b/src/Entity/Submission.php
@@ -2,10 +2,11 @@
 
 namespace App\Entity;
 
+use App\Repository\SubmissionRepository;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
 
-#[ORM\Entity]
+#[ORM\Entity(repositoryClass: SubmissionRepository::class)]
 #[ORM\Table(name: 'submissions')]
 #[UniqueEntity(fields: ['checklist', 'mitarbeiterId'], message: 'Für diese Person wurde die Stückliste bereits ausgefüllt.')]
 class Submission


### PR DESCRIPTION
## Summary
- associate Submission entity with its custom repository to allow calls to findOneByChecklistAndMitarbeiterId via entity manager

## Testing
- `./vendor/bin/phpunit`
- `./vendor/bin/phpstan analyse --memory-limit=512M` *(fails: 7 errors)*

------
https://chatgpt.com/codex/tasks/task_e_689dcae201148331ad02f2dc502824b3