### PR TITLE
refactor: centralize user command logic

### DIFF
--- a/src/Command/AbstractUserCommand.php
+++ b/src/Command/AbstractUserCommand.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace App\Command;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+
+/**
+ * Basisklasse für Benutzerbefehle mit gemeinsamen Argumenten und Validierung.
+ */
+abstract class AbstractUserCommand extends Command
+{
+    public function __construct(
+        protected EntityManagerInterface $entityManager,
+        protected UserPasswordHasherInterface $passwordHasher
+    ) {
+        parent::__construct();
+    }
+
+    /**
+     * Konfiguriert gemeinsame Argumente für Benutzerbefehle.
+     */
+    protected function configure(): void
+    {
+        $this
+            ->addArgument('email', InputArgument::REQUIRED, 'E-Mail-Adresse des Benutzers')
+            ->addArgument('password', InputArgument::REQUIRED, 'Passwort (mindestens 16 Zeichen)');
+    }
+
+    /**
+     * Führt die gemeinsame Validierung aus und delegiert die Verarbeitung.
+     */
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+        $email = $input->getArgument('email');
+        if (!is_string($email)) {
+            $io->error('Ungültige E-Mail-Adresse.');
+            return Command::FAILURE;
+        }
+
+        $password = $input->getArgument('password');
+        if (!is_string($password)) {
+            $io->error('Ungültiges Passwort.');
+            return Command::FAILURE;
+        }
+
+        if (strlen($password) < 16) {
+            $io->error('Das Passwort muss mindestens 16 Zeichen lang sein.');
+            return Command::FAILURE;
+        }
+
+        return $this->handle($io, $email, $password);
+    }
+
+    /**
+     * Führt die befehlspezifische Logik aus.
+     */
+    abstract protected function handle(SymfonyStyle $io, string $email, string $password): int;
+}
+

--- a/src/Command/ChangePasswordCommand.php
+++ b/src/Command/ChangePasswordCommand.php
@@ -6,9 +6,6 @@ use App\Entity\User;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\Input\InputArgument;
-use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
 
@@ -16,66 +13,26 @@ use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
     name: 'app:user:change-password',
     description: 'Ändert das Passwort eines bestehenden Benutzers',
 )]
-class ChangePasswordCommand extends Command
+class ChangePasswordCommand extends AbstractUserCommand
 {
-    /**
-     * @param EntityManagerInterface      $entityManager Datenbankzugriff
-     * @param UserPasswordHasherInterface $passwordHasher Passwort-Hasher
-     */
     public function __construct(
-        private EntityManagerInterface $entityManager,
-        private UserPasswordHasherInterface $passwordHasher
+        EntityManagerInterface $entityManager,
+        UserPasswordHasherInterface $passwordHasher
     ) {
-        parent::__construct();
-    }
-
-    /**
-     * Legt die benötigten Argumente für den Befehl fest.
-     */
-    protected function configure(): void
-    {
-        $this
-            ->addArgument('email', InputArgument::REQUIRED, 'E-Mail-Adresse des Benutzers')
-            ->addArgument('password', InputArgument::REQUIRED, 'Neues Passwort (mindestens 16 Zeichen)');
+        parent::__construct($entityManager, $passwordHasher);
     }
 
     /**
      * Ändert das Passwort eines vorhandenen Benutzers.
-     *
-     * @param InputInterface  $input  Eingabedaten der Konsole
-     * @param OutputInterface $output Ausgabeschnittstelle
-     *
-     * @return int Statuscode
      */
-    protected function execute(InputInterface $input, OutputInterface $output): int
+    protected function handle(SymfonyStyle $io, string $email, string $password): int
     {
-        $io = new SymfonyStyle($input, $output);
-        $email = $input->getArgument('email');
-        if (!is_string($email)) {
-            $io->error('Ungültige E-Mail-Adresse.');
-            return Command::FAILURE;
-        }
-
-        $password = $input->getArgument('password');
-        if (!is_string($password)) {
-            $io->error('Ungültiges Passwort.');
-            return Command::FAILURE;
-        }
-
-        // Passwort-Validierung
-        if (strlen($password) < 16) {
-            $io->error('Das Passwort muss mindestens 16 Zeichen lang sein.');
-            return Command::FAILURE;
-        }
-
-        // Benutzer suchen
         $user = $this->entityManager->getRepository(User::class)->findOneBy(['email' => $email]);
         if (!$user) {
             $io->error('Benutzer mit dieser E-Mail-Adresse wurde nicht gefunden.');
             return Command::FAILURE;
         }
 
-        // Passwort ändern
         $hashedPassword = $this->passwordHasher->hashPassword($user, $password);
         $user->setPassword($hashedPassword);
 

--- a/src/Command/CreateUserCommand.php
+++ b/src/Command/CreateUserCommand.php
@@ -6,9 +6,6 @@ use App\Entity\User;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\Input\InputArgument;
-use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
 
@@ -16,68 +13,30 @@ use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
     name: 'app:user:create',
     description: 'Erstellt einen neuen Admin-Benutzer',
 )]
-class CreateUserCommand extends Command
+class CreateUserCommand extends AbstractUserCommand
 {
-    /**
-     * @param EntityManagerInterface      $entityManager Datenbankzugriff
-     * @param UserPasswordHasherInterface $passwordHasher Dienst zum Hashen des Passworts
-     */
-    // Konfiguriert den Befehl, legt Name, Beschreibung und Argumente fest
     public function __construct(
-        private EntityManagerInterface $entityManager,
-        private UserPasswordHasherInterface $passwordHasher
+        EntityManagerInterface $entityManager,
+        UserPasswordHasherInterface $passwordHasher
     ) {
-        parent::__construct();
+        parent::__construct($entityManager, $passwordHasher);
     }
 
     /**
-     * Definiert die erwarteten Argumente für den Konsolenbefehl.
+     * Erstellt einen neuen Benutzer.
      */
-    protected function configure(): void
+    protected function handle(SymfonyStyle $io, string $email, string $password): int
     {
-        $this
-            ->addArgument('email', InputArgument::REQUIRED, 'E-Mail-Adresse des Benutzers')
-            ->addArgument('password', InputArgument::REQUIRED, 'Passwort (mindestens 16 Zeichen)');
-    // Führt den Befehl aus, erstellt und speichert einen neuen Benutzer
-    }
-
-    /**
-     * Führt den Befehl aus und erstellt den Benutzer.
-     *
-     * @param InputInterface  $input  Eingabeparameter der Konsole
-     * @param OutputInterface $output Ausgabeschnittstelle
-     *
-     * @return int Statuscode
-     */
-    protected function execute(InputInterface $input, OutputInterface $output): int
-    {
-        $io = new SymfonyStyle($input, $output);
-        $email = $input->getArgument('email');
-        $password = $input->getArgument('password');
-
-        if (!is_string($email) || !is_string($password)) {
-            $io->error('Ungültige Eingabewerte.');
-            return Command::FAILURE;
-        }
-
-        // Passwort-Validierung
-        if (strlen($password) < 16) {
-            $io->error('Das Passwort muss mindestens 16 Zeichen lang sein.');
-            return Command::FAILURE;
-        }
-
-        // Prüfen ob Benutzer bereits existiert
         $existingUser = $this->entityManager->getRepository(User::class)->findOneBy(['email' => $email]);
         if ($existingUser) {
             $io->warning('Benutzer mit dieser E-Mail-Adresse existiert bereits.');
             return Command::FAILURE;
         }
 
-        // Benutzer erstellen
         $user = new User();
         $user->setEmail($email);
         $user->setRoles(['ROLE_ADMIN']);
-        
+
         $hashedPassword = $this->passwordHasher->hashPassword($user, $password);
         $user->setPassword($hashedPassword);
 


### PR DESCRIPTION
## Summary
- extract common user argument/validation logic into `AbstractUserCommand`
- update `ChangePasswordCommand` and `CreateUserCommand` to extend the base class

## Testing
- `vendor/bin/phpunit` *(fails: Trying to configure method "getChecklistOr404" which cannot be configured)*

------
https://chatgpt.com/codex/tasks/task_e_689ecd6c303c8331a885635f618df55f