### PR TITLE
refactor: centralize CSRF-protected deletions

### DIFF
--- a/src/Controller/Admin/GroupController.php
+++ b/src/Controller/Admin/GroupController.php
@@ -7,6 +7,7 @@ use App\Entity\ChecklistGroup;
 use App\Entity\GroupItem;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use App\Service\CsrfDeletionHelper;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
@@ -14,6 +15,7 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 #[IsGranted('ROLE_ADMIN')]
 class GroupController extends AbstractController
 {
+    use CsrfDeletionHelper;
     /**
      * Konstruktor mit EntityManager für Gruppenoperationen.
      *
@@ -165,12 +167,7 @@ class GroupController extends AbstractController
     {
         $checklistId = $group->getChecklist()?->getId();
 
-        if ($this->isCsrfTokenValid('delete' . $group->getId(), $request->request->getString('_token'))) {
-            $this->entityManager->remove($group);
-            $this->entityManager->flush();
-
-            $this->addFlash('success', 'Gruppe wurde erfolgreich gelöscht.');
-        }
+        $this->handleCsrfDeletion($request, $group, 'Gruppe wurde erfolgreich gelöscht.');
 
         return $this->redirectToRoute('admin_checklist_edit', ['id' => $checklistId]);
     }
@@ -242,12 +239,7 @@ class GroupController extends AbstractController
     {
         $checklistId = $item->getGroup()?->getChecklist()?->getId();
 
-        if ($this->isCsrfTokenValid('delete' . $item->getId(), $request->request->getString('_token'))) {
-            $this->entityManager->remove($item);
-            $this->entityManager->flush();
-
-            $this->addFlash('success', 'Element wurde erfolgreich gelöscht.');
-        }
+        $this->handleCsrfDeletion($request, $item, 'Element wurde erfolgreich gelöscht.');
 
         return $this->redirectToRoute('admin_checklist_edit', ['id' => $checklistId]);
     }

--- a/src/Controller/Admin/SubmissionController.php
+++ b/src/Controller/Admin/SubmissionController.php
@@ -7,6 +7,7 @@ use App\Repository\ChecklistRepository;
 use App\Repository\SubmissionRepository;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use App\Service\CsrfDeletionHelper;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
@@ -14,6 +15,7 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 #[IsGranted('ROLE_ADMIN')]
 class SubmissionController extends AbstractController
 {
+    use CsrfDeletionHelper;
     /**
      * Konstruktor stellt benötigte Repositories bereit.
      *
@@ -97,14 +99,8 @@ class SubmissionController extends AbstractController
             throw $this->createNotFoundException(sprintf('Zugehörige Checkliste für Submission #%d nicht gefunden.', $submission->getId()));
         }
         $checklistId = $checklist->getId();
-        $token = $request->request->get('_token');
-        $token = is_string($token) ? $token : null;
 
-        if ($this->isCsrfTokenValid('delete' . $submission->getId(), $token)) {
-            $this->entityManager->remove($submission);
-            $this->entityManager->flush();
-            $this->addFlash('success', 'Einsendung wurde erfolgreich gel\xC3\xB6scht.');
-        }
+        $this->handleCsrfDeletion($request, $submission, 'Einsendung wurde erfolgreich gelöscht.');
 
         return $this->redirectToRoute('admin_submissions_checklist', ['checklistId' => $checklistId]);
     }

--- a/src/Controller/Admin/UserController.php
+++ b/src/Controller/Admin/UserController.php
@@ -5,6 +5,7 @@ namespace App\Controller\Admin;
 use App\Entity\User;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use App\Service\CsrfDeletionHelper;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
@@ -13,6 +14,7 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 #[IsGranted('ROLE_ADMIN')]
 class UserController extends AbstractController
 {
+    use CsrfDeletionHelper;
     /**
      * Konstruktor stellt EntityManager und PasswordHasher bereit.
      *
@@ -133,11 +135,7 @@ class UserController extends AbstractController
      */
     public function delete(Request $request, User $user): Response
     {
-        if ($this->isCsrfTokenValid('delete' . $user->getId(), (string) $request->request->get('_token'))) {
-            $this->entityManager->remove($user);
-            $this->entityManager->flush();
-            $this->addFlash('success', 'Benutzer wurde erfolgreich gelöscht.');
-        }
+        $this->handleCsrfDeletion($request, $user, 'Benutzer wurde erfolgreich gelöscht.');
 
         return $this->redirectToRoute('admin_users');
     }

--- a/src/Service/CsrfDeletionHelper.php
+++ b/src/Service/CsrfDeletionHelper.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Service;
+
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Helfertrait zum Löschen von Entitäten mit CSRF-Schutz.
+ */
+trait CsrfDeletionHelper
+{
+    /**
+     * Prüft den CSRF-Token und entfernt anschließend die Entität.
+     *
+     * @param Request        $request     Aktuelle HTTP-Anfrage
+     * @param object         $entity      Zu löschende Entität
+     * @param string         $flashMessage Erfolgsmeldung für den Benutzer
+     * @param callable|null  $preRemoval  Optionaler Callback vor dem Entfernen
+     */
+    private function handleCsrfDeletion(Request $request, object $entity, string $flashMessage, ?callable $preRemoval = null): void
+    {
+        $token = $request->request->get('_token');
+        $token = is_string($token) ? $token : null;
+
+        if ($this->isCsrfTokenValid('delete' . $entity->getId(), $token)) {
+            if ($preRemoval !== null) {
+                $preRemoval($entity);
+            }
+
+            $this->entityManager->remove($entity);
+            $this->entityManager->flush();
+            $this->addFlash('success', $flashMessage);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `CsrfDeletionHelper` trait for CSRF token validation and entity deletion
- refactor controllers to use helper for deletion actions

## Testing
- `vendor/bin/phpunit` *(fails: Trying to configure method "getChecklistOr404" which cannot be configured because it does not exist, has not been specified, is final, or is static)*
- `vendor/bin/phpstan analyse` *(fails: PHPStan process crashed because it reached configured PHP memory limit: 128M)*

------
https://chatgpt.com/codex/tasks/task_e_689ecf7269608331b22848051078e6f3