### PR TITLE
Add integration test for dashboard controller

### DIFF
--- a/tests/Controller/Admin/DashboardControllerFunctionalTest.php
+++ b/tests/Controller/Admin/DashboardControllerFunctionalTest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Tests\Controller\Admin;
+
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+class DashboardControllerFunctionalTest extends KernelTestCase
+{
+    public function testAdminDashboardRouteIsRegistered(): void
+    {
+        $kernel = static::createKernel();
+        $kernel->boot();
+
+        $container = $kernel->getContainer();
+        $router = $container->get('router');
+        $route = $router->getRouteCollection()->get('admin_dashboard');
+
+        $this->assertNotNull($route, 'Route "admin_dashboard" should be registered');
+        $this->assertSame('/admin', $route->getPath());
+    }
+}


### PR DESCRIPTION
## Summary
- add Kernel-based integration test ensuring admin dashboard route is registered at `/admin`

## Testing
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_68a8064144988331addafe91339e6657