### PR TITLE
Add functional and integration tests for ChecklistController

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -147,12 +147,12 @@ migrate: ## doctrine:migrations:migrate (no interaction)
 ## Tests (PHPUnit)
 
 test: ## Führt PHPUnit-Tests im PHP-Container aus
-	@echo "==> Running PHPUnit tests inside $(PHP_SERVICE)"
-	@$(DC_BASE) $(DC_ARGS) exec -T $(PHP_SERVICE) bash -lc "if [ -f vendor/bin/phpunit ]; then vendor/bin/phpunit --colors=always; else echo 'phpunit not found, run composer install first'; exit 1; fi"
+	@echo "==> Running PHPUnit tests inside $(PHP_SERVICE) (APP_ENV=test)"
+	@$(DC_BASE) $(DC_ARGS) exec -e APP_ENV=test -T $(PHP_SERVICE) bash -lc "if [ -f vendor/bin/phpunit ]; then vendor/bin/phpunit --colors=always; else echo 'phpunit not found, run composer install first'; exit 1; fi"
 
 coverage: ## Erzeugt Coverage (HTML + text)
-	@echo "==> Running PHPUnit coverage inside $(PHP_SERVICE)"
-	@$(DC_BASE) $(DC_ARGS) exec -T $(PHP_SERVICE) /bin/sh -lc "echo '=== php -v ===' && php -v && echo '=== php -m (xdebug?) ===' && php -m | grep -i xdebug || true && if [ -f vendor/bin/phpunit ]; then mkdir -p var/coverage && XDEBUG_MODE=coverage XDEBUG_CONFIG='start_with_request=1' vendor/bin/phpunit --colors=always --coverage-html var/coverage --coverage-text; else echo 'phpunit not found, run composer install first'; exit 1; fi"
+	@echo "==> Running PHPUnit coverage inside $(PHP_SERVICE) (APP_ENV=test)"
+	@$(DC_BASE) $(DC_ARGS) exec -e APP_ENV=test -T $(PHP_SERVICE) /bin/sh -lc "echo '=== php -v ===' && php -v && echo '=== php -m (xdebug?) ===' && php -m | grep -i xdebug || true && if [ -f vendor/bin/phpunit ]; then mkdir -p var/coverage && XDEBUG_MODE=coverage XDEBUG_CONFIG='start_with_request=1' vendor/bin/phpunit --colors=always --coverage-html var/coverage --coverage-text; else echo 'phpunit not found, run composer install first'; exit 1; fi"
 
 ## Recreate DB: stop, remove volumes and bring up database only
 
@@ -213,8 +213,6 @@ install: composer-install ## alias: install -> composer-install
 
 clear-cache: cache-clear ## alias
 
-coverage: ## Führt PHPUnit mit Coverage-Ausgabe aus (Text + HTML -> var/coverage)
-	docker compose exec -e APP_ENV=$(ENV) -e APP_DEBUG=$(APP_DEBUG) -e XDEBUG_MODE=coverage php vendor/bin/phpunit --coverage-text --coverage-html=var/coverage
 
 phpstan: ## Führt statische Analyse mit PHPStan aus
 	@$(DC_BASE) $(DC_ARGS) exec -T $(PHP_SERVICE) vendor/bin/phpstan analyse --memory-limit=512M || true

--- a/tests/Controller/ChecklistControllerFunctionalTest.php
+++ b/tests/Controller/ChecklistControllerFunctionalTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Tests\Controller;
+
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+class ChecklistControllerFunctionalTest extends KernelTestCase
+{
+    public function testChecklistRoutesAreRegistered(): void
+    {
+        self::bootKernel();
+        $router = self::getContainer()->get('router');
+        $collection = $router->getRouteCollection();
+
+        $show = $collection->get('checklist_show');
+        $this->assertNotNull($show, 'Route "checklist_show" should exist');
+        $this->assertSame('/checklist/{id}', $show->getPath());
+
+        $submit = $collection->get('checklist_submit');
+        $this->assertNotNull($submit, 'Route "checklist_submit" should exist');
+        $this->assertSame('/checklist/{id}/submit', $submit->getPath());
+
+        $form = $collection->get('checklist_form');
+        $this->assertNotNull($form, 'Route "checklist_form" should exist');
+        $this->assertSame('/form', $form->getPath());
+
+        $selection = $collection->get('checklist_selection');
+        $this->assertNotNull($selection, 'Route "checklist_selection" should exist');
+        $this->assertSame('/auswahl', $selection->getPath());
+    }
+}

--- a/tests/Controller/ChecklistControllerIntegrationTest.php
+++ b/tests/Controller/ChecklistControllerIntegrationTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Tests\Controller;
+
+use App\Controller\ChecklistController;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+class ChecklistControllerIntegrationTest extends KernelTestCase
+{
+    public function testControllerIsAutowired(): void
+    {
+        self::bootKernel();
+        $controller = self::getContainer()->get(ChecklistController::class);
+        $this->assertInstanceOf(ChecklistController::class, $controller);
+    }
+
+    public function testRouterGeneratesChecklistShowUrl(): void
+    {
+        self::bootKernel();
+        $router = self::getContainer()->get('router');
+        $url = $router->generate('checklist_show', ['id' => 99]);
+        $this->assertSame('/checklist/99', $url);
+    }
+}


### PR DESCRIPTION
## Summary
- add functional tests asserting public checklist routes are registered
- add integration tests ensuring ChecklistController is autowired and routes generate expected URLs

## Testing
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_68a80f741040833181efcc32db03aec7