### PR TITLE
Add functional and integration tests for ChecklistLinkController

### DIFF
--- a/tests/Controller/Admin/ChecklistLinkControllerFunctionalTest.php
+++ b/tests/Controller/Admin/ChecklistLinkControllerFunctionalTest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Tests\Controller\Admin;
+
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+class ChecklistLinkControllerFunctionalTest extends KernelTestCase
+{
+    public function testAdminChecklistSendLinkRouteIsRegistered(): void
+    {
+        $kernel = static::createKernel();
+        $kernel->boot();
+
+        $router = $kernel->getContainer()->get('router');
+        $route = $router->getRouteCollection()->get('admin_checklist_send_link');
+
+        $this->assertNotNull($route, 'Route "admin_checklist_send_link" should be registered');
+        $this->assertSame('/admin/checklists/{id}/send-link', $route->getPath());
+    }
+}

--- a/tests/Controller/Admin/ChecklistLinkControllerIntegrationTest.php
+++ b/tests/Controller/Admin/ChecklistLinkControllerIntegrationTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Tests\Controller\Admin;
+
+use App\Controller\Admin\ChecklistLinkController;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+class ChecklistLinkControllerIntegrationTest extends KernelTestCase
+{
+    public function testControllerIsAutowired(): void
+    {
+        self::bootKernel();
+        $controller = self::getContainer()->get(ChecklistLinkController::class);
+        $this->assertInstanceOf(ChecklistLinkController::class, $controller);
+    }
+
+    public function testRouterGeneratesSendLinkUrl(): void
+    {
+        self::bootKernel();
+        $router = self::getContainer()->get('router');
+        $url = $router->generate('admin_checklist_send_link', ['id' => 42]);
+        $this->assertSame('/admin/checklists/42/send-link', $url);
+    }
+}


### PR DESCRIPTION
## Summary
- add functional test confirming admin checklist send-link route registration
- add integration test for ChecklistLinkController autowiring and URL generation

## Testing
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_68a81d1de28883319b2a88188ad276d0